### PR TITLE
Feature/wa 271 gatekeeper repo

### DIFF
--- a/Common/Common/Assertable.swift
+++ b/Common/Common/Assertable.swift
@@ -6,51 +6,51 @@ import Foundation
 
 public protocol Assertable {
 
-    func assertArgument(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws
-    func assertNil(_ assertion: @autoclosure () -> Any?, _ error: Swift.Error) throws
-    func assertNotNil(_ assertion: @autoclosure () -> Any?, _ error: Swift.Error) throws
-    func assertTrue(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws
-    func assertFalse(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws
-    func assertEqual<T>(_ expression1: @autoclosure () -> T,
-                        _ expression2: @autoclosure () -> T,
+    func assertArgument(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws
+    func assertNil(_ assertion: @autoclosure () throws -> Any?, _ error: Swift.Error) throws
+    func assertNotNil(_ assertion: @autoclosure () throws -> Any?, _ error: Swift.Error) throws
+    func assertTrue(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws
+    func assertFalse(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws
+    func assertEqual<T>(_ expression1: @autoclosure () throws -> T,
+                        _ expression2: @autoclosure () throws -> T,
                         _ error: Swift.Error) throws where T: Equatable
-    func assertNotEqual<T>(_ expression1: @autoclosure () -> T,
-                           _ expression2: @autoclosure () -> T,
+    func assertNotEqual<T>(_ expression1: @autoclosure () throws -> T,
+                           _ expression2: @autoclosure () throws -> T,
                            _ error: Swift.Error) throws where T: Equatable
 }
 
 public extension Assertable {
 
-    func assertArgument(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws {
-        if !assertion() { throw error }
+    func assertArgument(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws {
+        if try !assertion() { throw error }
     }
 
-    func assertNil(_ assertion: @autoclosure () -> Any?, _ error: Swift.Error) throws {
-        if assertion() != nil { throw error }
+    func assertNil(_ assertion: @autoclosure () throws -> Any?, _ error: Swift.Error) throws {
+        if try assertion() != nil { throw error }
     }
 
-    func assertNotNil(_ assertion: @autoclosure () -> Any?, _ error: Swift.Error) throws {
-        if assertion() == nil { throw error }
+    func assertNotNil(_ assertion: @autoclosure () throws -> Any?, _ error: Swift.Error) throws {
+        if try assertion() == nil { throw error }
     }
 
-    func assertTrue(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws {
-        if !assertion() { throw error }
+    func assertTrue(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws {
+        if try !assertion() { throw error }
     }
 
-    func assertFalse(_ assertion: @autoclosure () -> Bool, _ error: Swift.Error) throws {
+    func assertFalse(_ assertion: @autoclosure () throws -> Bool, _ error: Swift.Error) throws {
         try assertTrue(!assertion(), error)
     }
 
-    func assertEqual<T>(_ expression1: @autoclosure () -> T,
-                        _ expression2: @autoclosure () -> T,
+    func assertEqual<T>(_ expression1: @autoclosure () throws -> T,
+                        _ expression2: @autoclosure () throws -> T,
                         _ error: Swift.Error) throws where T: Equatable {
-        if expression1() != expression2() { throw error }
+        if try expression1() != expression2() { throw error }
     }
 
-    func assertNotEqual<T>(_ expression1: @autoclosure () -> T,
-                           _ expression2: @autoclosure () -> T,
+    func assertNotEqual<T>(_ expression1: @autoclosure () throws -> T,
+                           _ expression2: @autoclosure () throws -> T,
                            _ error: Swift.Error) throws where T: Equatable {
-        if expression1() == expression2() { throw error }
+        if try expression1() == expression2() { throw error }
     }
 
 }

--- a/IdentityAccess/IdentityAccess.xcodeproj/project.pbxproj
+++ b/IdentityAccess/IdentityAccess.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		0A44F9C520908BBD00BB7101 /* DBSingleUserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A44F9C420908BBD00BB7101 /* DBSingleUserRepository.swift */; };
 		0A44F9CB20908BE400BB7101 /* DBSingleUserRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A44F9CA20908BE400BB7101 /* DBSingleUserRepositoryTests.swift */; };
 		0A44F9CD2090B95700BB7101 /* DBSingleUserRepositoryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A44F9CC2090B95700BB7101 /* DBSingleUserRepositoryIntegrationTests.swift */; };
+		0A48A0722092003C00B704AD /* DBSingleGatekeeperRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A48A0712092003C00B704AD /* DBSingleGatekeeperRepository.swift */; };
+		0A48A0792092008100B704AD /* DBSingleGatekeeperRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A48A0782092008100B704AD /* DBSingleGatekeeperRepositoryTests.swift */; };
+		0A48A07B2092025A00B704AD /* DBSingleGatekeeperRepositoryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A48A07A2092025A00B704AD /* DBSingleGatekeeperRepositoryIntegrationTests.swift */; };
 		0A537A92207CE74100921FB9 /* UserDefaultKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A537A81207CE74000921FB9 /* UserDefaultKeys.swift */; };
 		0A537A93207CE74100921FB9 /* KeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A537A82207CE74000921FB9 /* KeyValueStore.swift */; };
 		0A537A95207CE74100921FB9 /* SecureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A537A84207CE74000921FB9 /* SecureStore.swift */; };
@@ -313,6 +316,9 @@
 		0A44F9C420908BBD00BB7101 /* DBSingleUserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleUserRepository.swift; sourceTree = "<group>"; };
 		0A44F9CA20908BE400BB7101 /* DBSingleUserRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleUserRepositoryTests.swift; sourceTree = "<group>"; };
 		0A44F9CC2090B95700BB7101 /* DBSingleUserRepositoryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleUserRepositoryIntegrationTests.swift; sourceTree = "<group>"; };
+		0A48A0712092003C00B704AD /* DBSingleGatekeeperRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleGatekeeperRepository.swift; sourceTree = "<group>"; };
+		0A48A0782092008100B704AD /* DBSingleGatekeeperRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleGatekeeperRepositoryTests.swift; sourceTree = "<group>"; };
+		0A48A07A2092025A00B704AD /* DBSingleGatekeeperRepositoryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBSingleGatekeeperRepositoryIntegrationTests.swift; sourceTree = "<group>"; };
 		0A537A64207CE5BC00921FB9 /* libIdentityAccessDomainModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libIdentityAccessDomainModel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A537A7C207CE73F00921FB9 /* IdentityAccessDomainModel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IdentityAccessDomainModel-Bridging-Header.h"; sourceTree = "<group>"; };
 		0A537A80207CE74000921FB9 /* DomainRegistryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainRegistryTests.swift; sourceTree = "<group>"; };
@@ -750,6 +756,9 @@
 				0A44F9CA20908BE400BB7101 /* DBSingleUserRepositoryTests.swift */,
 				0AFFF42D2084BF850030200C /* InMemoryGatekeeperRepositoryTests.swift */,
 				0AFFF42F2084C01A0030200C /* InMemoryGatekeeperRepository.swift */,
+				0A48A0712092003C00B704AD /* DBSingleGatekeeperRepository.swift */,
+				0A48A0782092008100B704AD /* DBSingleGatekeeperRepositoryTests.swift */,
+				0A48A07A2092025A00B704AD /* DBSingleGatekeeperRepositoryIntegrationTests.swift */,
 				0AD8599E208F3B9B0084C0B9 /* Database.swift */,
 				0A666D3B208A07A90034FF66 /* SQLiteDatabase.swift */,
 				0AD85992208F39C00084C0B9 /* SQLiteConnection.swift */,
@@ -1174,6 +1183,7 @@
 				0A537B0F207CF2D600921FB9 /* LogFormatter.swift in Sources */,
 				0AD85995208F39CE0084C0B9 /* SQLiteStatement.swift in Sources */,
 				0AD85997208F39E70084C0B9 /* SQLiteResultSet.swift in Sources */,
+				0A48A0722092003C00B704AD /* DBSingleGatekeeperRepository.swift in Sources */,
 				0A537AE9207CF02C00921FB9 /* MockLogger.swift in Sources */,
 				0AD8598D208F39830084C0B9 /* MockFileManager.swift in Sources */,
 				0A537B19207CF2D600921FB9 /* BiometricService.swift in Sources */,
@@ -1191,6 +1201,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0A537BA8207CF93F00921FB9 /* EthereumAccountTests.swift in Sources */,
+				0A48A07B2092025A00B704AD /* DBSingleGatekeeperRepositoryIntegrationTests.swift in Sources */,
 				0A66598B208A403500A4C8CE /* SQLiteDatabaseTests.swift in Sources */,
 				0A44F9CB20908BE400BB7101 /* DBSingleUserRepositoryTests.swift in Sources */,
 				0A537BAB207CF96500921FB9 /* CrashlyticsLoggerTests.swift in Sources */,
@@ -1204,6 +1215,7 @@
 				0A44F9A9208F6F4500BB7101 /* CSQLite3ErrorTests.swift in Sources */,
 				0A537B3B207CF7F000921FB9 /* SystemClockServiceIntegrationTests.swift in Sources */,
 				0A537BAA207CF95B00921FB9 /* ConsoleLoggerTests.swift in Sources */,
+				0A48A0792092008100B704AD /* DBSingleGatekeeperRepositoryTests.swift in Sources */,
 				0A537B39207CF63800921FB9 /* BiometricServiceTests.swift in Sources */,
 				0AD859A1208F5C280084C0B9 /* SQLiteDatabaseIntegrationTests.swift in Sources */,
 				0A44F9CD2090B95700BB7101 /* DBSingleUserRepositoryIntegrationTests.swift in Sources */,

--- a/IdentityAccess/IdentityAccessDomainModel/AuthenticationPolicy.swift
+++ b/IdentityAccess/IdentityAccessDomainModel/AuthenticationPolicy.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-public struct AuthenticationPolicy: Hashable, Assertable {
+public struct AuthenticationPolicy: Hashable, Assertable, Codable {
 
     public enum Error: Swift.Error, Hashable {
         case sessionDurationMustBePositive

--- a/IdentityAccess/IdentityAccessDomainModel/GatekeeperTests.swift
+++ b/IdentityAccess/IdentityAccessDomainModel/GatekeeperTests.swift
@@ -112,6 +112,11 @@ class GatekeeperTests: DomainTestCase {
         XCTAssertThrowsError(try gatekeeper.changeBlockDuration(-1))
     }
 
+    func test_codable() throws {
+        let data = try gatekeeper.data()
+        let other = try Gatekeeper(data: data)
+        XCTAssertEqual(other, gatekeeper)
+    }
 }
 
 extension GatekeeperTests {

--- a/IdentityAccess/IdentityAccessDomainModel/Session.swift
+++ b/IdentityAccess/IdentityAccessDomainModel/Session.swift
@@ -16,6 +16,14 @@ public class Session: IdentifiableEntity<SessionID> {
         case sessionWasFinishedAlready
     }
 
+    struct State: Codable {
+        fileprivate let id: String
+        fileprivate let duration: TimeInterval
+        fileprivate let startedAt: Date?
+        fileprivate let endedAt: Date?
+        fileprivate let updatedAt: Date?
+    }
+
     private let duration: TimeInterval
     private var startedAt: Date?
     private var endedAt: Date?
@@ -25,6 +33,22 @@ public class Session: IdentifiableEntity<SessionID> {
         duration = durationInSeconds
         super.init(id: id)
         try assertTrue(durationInSeconds > 0, Error.invalidDuration)
+    }
+
+    public convenience init(data: Data) throws {
+        let decoder = PropertyListDecoder()
+        let state = try decoder.decode(State.self, from: data)
+        try self.init(id: try SessionID(state.id), durationInSeconds: state.duration)
+        startedAt = state.startedAt
+        endedAt = state.endedAt
+        updatedAt = state.updatedAt
+    }
+
+    public func data() throws -> Data {
+        let state = State(id: id.id, duration: duration, startedAt: startedAt, endedAt: endedAt, updatedAt: updatedAt)
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        return try encoder.encode(state)
     }
 
     public func isActiveAt(_ time: Date) -> Bool {

--- a/IdentityAccess/IdentityAccessDomainModel/SessionTests.swift
+++ b/IdentityAccess/IdentityAccessDomainModel/SessionTests.swift
@@ -76,6 +76,12 @@ class SessionTests: XCTestCase {
         XCTAssertTrue(session.isActiveAt(Date(timeIntervalSinceNow: 2)))
     }
 
+    func test_codable() throws {
+        let data = try session.data()
+        let other = try Session(data: data)
+        XCTAssertEqual(other, session)
+    }
+
 }
 
 extension SessionTests {

--- a/IdentityAccess/IdentityAccessDomainModel/User.swift
+++ b/IdentityAccess/IdentityAccessDomainModel/User.swift
@@ -38,7 +38,7 @@ public class User: IdentifiableEntity<UserID> {
         self.password = password
     }
 
-    func attachSession(id: SessionID) {
+    public func attachSession(id: SessionID) {
         sessionID = id
     }
 

--- a/IdentityAccess/IdentityAccessImplementations/ethereum/EncryptionServiceTests.swift
+++ b/IdentityAccess/IdentityAccessImplementations/ethereum/EncryptionServiceTests.swift
@@ -49,6 +49,10 @@ class EncryptionServiceTests: XCTestCase {
         XCTAssertNotNil(address.data)
         XCTAssertEqual(address.data.count, 20)
     }
+
+    func test_encryption() {
+        XCTAssertNotEqual(service.encrypted("text"), "text")
+    }
 }
 
 extension EncryptionServiceTests {

--- a/IdentityAccess/IdentityAccessImplementations/persistence/CSQLite3.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/CSQLite3.swift
@@ -9,15 +9,16 @@ open class CSQLite3 {
 
     public init() {}
 
-    open var SQLITE_VERSION: String {
-        return SQLite3.SQLITE_VERSION
-    }
-    open var SQLITE_VERSION_NUMBER: Int32 {
-        return SQLite3.SQLITE_VERSION_NUMBER
-    }
-    open var SQLITE_SOURCE_ID: String {
-        return SQLite3.SQLITE_SOURCE_ID
-    }
+    open var SQLITE_VERSION: String { return SQLite3.SQLITE_VERSION }
+    open var SQLITE_VERSION_NUMBER: Int32 { return SQLite3.SQLITE_VERSION_NUMBER }
+    open var SQLITE_SOURCE_ID: String { return SQLite3.SQLITE_SOURCE_ID }
+
+    public static var SQLITE_INTEGER: Int32 { return SQLite3.SQLITE_INTEGER }
+    public static var SQLITE_FLOAT: Int32 { return SQLite3.SQLITE_FLOAT }
+    public static var SQLITE_TEXT: Int32 { return SQLite3.SQLITE_TEXT }
+    public static var SQLITE_BLOB: Int32 { return SQLite3.SQLITE_BLOB }
+    public static var SQLITE_NULL: Int32 { return SQLite3.SQLITE_NULL }
+
     public static var SQLITE_OK: Int32 { return SQLite3.SQLITE_OK }
     public static var SQLITE_ERROR: Int32 { return SQLite3.SQLITE_ERROR }
     public static var SQLITE_INTERNAL: Int32 { return SQLite3.SQLITE_INTERNAL }
@@ -155,6 +156,10 @@ open class CSQLite3 {
         return SQLite3.sqlite3_column_count(pStmt)
     }
 
+    open func sqlite3_column_type(_ pStmt: OpaquePointer!, _ iCol: Int32) -> Int32 {
+        return SQLite3.sqlite3_column_type(pStmt, iCol)
+    }
+
     open func sqlite3_column_bytes(_ pStmt: OpaquePointer!, _ iCol: Int32) -> Int32 {
         return SQLite3.sqlite3_column_bytes(pStmt, iCol)
     }
@@ -169,6 +174,10 @@ open class CSQLite3 {
 
     open func sqlite3_column_text(_ pStmt: OpaquePointer!, _ iCol: Int32) -> UnsafePointer<UInt8>! {
         return SQLite3.sqlite3_column_text(pStmt, iCol)
+    }
+
+    open func sqlite3_column_blob(_ pStmt: OpaquePointer!, _ iCol: Int32) -> UnsafeRawPointer! {
+        return SQLite3.sqlite3_column_blob(pStmt, iCol)
     }
 
     open func sqlite3_reset(_ pStmt: OpaquePointer!) -> Int32 {
@@ -193,6 +202,14 @@ open class CSQLite3 {
                                 _ nByte: Int32,
                                 _ destructor: (@convention(c) (UnsafeMutableRawPointer?) -> Swift.Void)!) -> Int32 {
         return SQLite3.sqlite3_bind_text(pStmt, index, zValue, nByte, destructor)
+    }
+
+    open func sqlite3_bind_blob(_ pStmt: OpaquePointer!,
+                                _ index: Int32,
+                                _ zValue: UnsafeRawPointer!,
+                                _ nByte: Int32,
+                                _ destructor: (@convention(c) (UnsafeMutableRawPointer?) -> Swift.Void)!) -> Int32 {
+        return SQLite3.sqlite3_bind_blob(pStmt, index, zValue, nByte, destructor)
     }
 
     open func sqlite3_bind_parameter_index(_ pStmt: OpaquePointer!, _ zName: UnsafePointer<Int8>!) -> Int32 {

--- a/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepository.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepository.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright © 2018 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import IdentityAccessDomainModel
+import Common
+
+public class DBSingleGatekeeperRepository: SingleGatekeeperRepository, Assertable {
+
+    struct SQL {
+        static let createTable = """
+CREATE TABLE IF NOT EXISTS tbl_gatekeeper (
+    gatekeeper_id TEXT NOT NULL PRIMARY KEY,
+    data BLOB NOT NULL
+);
+"""
+        static let insertGatekeeper = "INSERT OR REPLACE INTO tbl_gatekeeper VALUES (?, ?);"
+        static let deleteGatekeeper = "DELETE FROM tbl_gatekeeper WHERE gatekeeper_id = ?;"
+        static let findGatekeeper = "SELECT gatekeeper_id, data FROM tbl_gatekeeper LIMIT 1;"
+    }
+
+    public enum Error: Swift.Error, Hashable {
+        case invalidGatekeeperIdStoredWithData
+    }
+
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    public func setUp() throws {
+        try db.executeUpdate(sql: SQL.createTable)
+    }
+
+    public func save(_ gatekeeper: Gatekeeper) throws {
+        try db.executeUpdate { conn in
+            let stmt = try conn.prepare(statement: SQL.insertGatekeeper)
+            try stmt.set(gatekeeper.id.id, at: 1)
+            try stmt.set(try gatekeeper.data(), at: 2)
+            return stmt
+        }
+    }
+
+    public func remove(_ gatekeeper: Gatekeeper) throws {
+        try db.executeUpdate { conn in
+            let stmt = try conn.prepare(statement: SQL.deleteGatekeeper)
+            try stmt.set(gatekeeper.id.id, at: 1)
+            return stmt
+        }
+    }
+
+    public func gatekeeper() -> Gatekeeper? {
+        return db.executeQuery(sql: SQL.findGatekeeper) { [unowned self] rs in
+            guard try rs.advanceToNextRow(),
+                let id = rs.string(at: 0),
+                let data = rs.data(at: 1) else {
+                    return nil
+            }
+            let gatekeeper = try Gatekeeper(data: data)
+            try self.assertEqual(gatekeeper.id, try GatekeeperID(id), Error.invalidGatekeeperIdStoredWithData)
+            return gatekeeper
+        }
+    }
+
+    public func nextId() -> GatekeeperID {
+        return try! GatekeeperID()
+    }
+
+}

--- a/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepositoryIntegrationTests.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepositoryIntegrationTests.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © 2018 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import IdentityAccessImplementations
+import IdentityAccessDomainModel
+
+class DBSingleGatekeeperRepositoryIntegrationTests: XCTestCase {
+
+    func test_all() throws {
+        let db = SQLiteDatabase(name: "DBSingleGatekeeperRepositoryIntegrationTests",
+                                fileManager: FileManager.default,
+                                sqlite: CSQLite3(),
+                                bundleId: "DBSingleGatekeeperRepositoryIntegrationTests")
+        try? db.destroy()
+        try db.create()
+        defer { try? db.destroy() }
+        let repo = DBSingleGatekeeperRepository(db: db)
+        try repo.setUp()
+        let gatekeeper = try Gatekeeper(id: repo.nextId(),
+                                        policy: AuthenticationPolicy(sessionDuration: 5,
+                                                                     maxFailedAttempts: 5,
+                                                                     blockDuration: 5))
+        try repo.save(gatekeeper)
+        let saved = repo.gatekeeper()
+        XCTAssertEqual(saved, gatekeeper)
+        XCTAssertEqual(saved?.policy, gatekeeper.policy)
+        try repo.remove(gatekeeper)
+        XCTAssertNil(repo.gatekeeper())
+    }
+
+}

--- a/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepositoryTests.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleGatekeeperRepositoryTests.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright © 2018 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import IdentityAccessImplementations
+import IdentityAccessDomainModel
+
+class DBSingleGatekeeperRepositoryTests: XCTestCase {
+
+    let trace = FunctionCallTrace()
+    var db: MockDatabase!
+    var repository: DBSingleGatekeeperRepository!
+
+    override func setUp() {
+        super.setUp()
+        db = MockDatabase(trace)
+        repository = DBSingleGatekeeperRepository(db: db)
+    }
+
+    func test_setUp() throws {
+        try repository.setUp()
+        let expectedCalls = [
+            "db.connection()",
+            "conn.prepare(\(DBSingleGatekeeperRepository.SQL.createTable))",
+            "stmt.execute()",
+            "db.close()"]
+        XCTAssertEqual(trace.log, expectedCalls, trace.diff(expectedCalls))
+    }
+
+    func test_save() throws {
+        let gatekeeper = try create()
+        try repository.save(gatekeeper)
+        let expectedCalls = [
+            "db.connection()",
+            "conn.prepare(\(DBSingleGatekeeperRepository.SQL.insertGatekeeper))",
+            "stmt.set(\(gatekeeper.id.id), 1)",
+            "stmt.set(\(try gatekeeper.data()), 2)",
+            "stmt.execute()",
+            "db.close()"]
+        XCTAssertEqual(trace.log, expectedCalls, trace.diff(expectedCalls))
+    }
+
+    func test_remove() throws {
+        let gatekeeper = try create()
+        try repository.remove(gatekeeper)
+        let expectedCalls = [
+            "db.connection()",
+            "conn.prepare(\(DBSingleGatekeeperRepository.SQL.deleteGatekeeper))",
+            "stmt.set(\(gatekeeper.id.id), 1)",
+            "stmt.execute()",
+            "db.close()"]
+        XCTAssertEqual(trace.log, expectedCalls, trace.diff(expectedCalls))
+    }
+
+    func test_gatekeeper() throws {
+        let gatekeeper = try create()
+        db.resultSet = [[gatekeeper.id.id, try gatekeeper.data()]]
+        _ = repository.gatekeeper()
+        let expectedCalls = [
+            "db.connection()",
+            "conn.prepare(\(DBSingleGatekeeperRepository.SQL.findGatekeeper))",
+            "stmt.execute()",
+            "rs.advanceToNextRow()",
+            "rs.string(0)",
+            "rs.data(1)",
+            "db.close()"]
+        XCTAssertEqual(trace.log, expectedCalls, trace.diff(expectedCalls))
+    }
+
+}
+
+extension DBSingleGatekeeperRepositoryTests {
+
+    func create() throws -> Gatekeeper {
+        let policy = try AuthenticationPolicy(sessionDuration: 15,
+                                              maxFailedAttempts: 5,
+                                              blockDuration: 10)
+        let gatekeeper = try Gatekeeper(id: repository.nextId(),
+                                        policy: policy)
+        return gatekeeper
+    }
+
+}

--- a/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleUserRepositoryTests.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/DBSingleUserRepositoryTests.swift
@@ -229,6 +229,14 @@ class MockStatement: Statement {
         trace.append("stmt.setNil(\(key))")
     }
 
+    func set(_ value: Data, at index: Int) throws {
+        trace.append("stmt.set(\(value), \(index))")
+    }
+
+    func set(_ value: Data, forKey key: String) throws {
+        trace.append("stmt.set(\(value), \(index))")
+    }
+
     func execute() throws -> ResultSet? {
         trace.append("stmt.execute()")
         if let rs = resultSet {
@@ -262,14 +270,19 @@ class MockResultSet: ResultSet {
         return resultSet[currentRow][index] as? String
     }
 
-    func int(at index: Int) -> Int {
-        trace.append("rs.int(\(index))")
-        return resultSet[currentRow][index] as? Int ?? 0
+    public func data(at index: Int) -> Data? {
+        trace.append("rs.data(\(index))")
+        return resultSet[currentRow][index] as? Data
     }
 
-    func double(at index: Int) -> Double {
+    func int(at index: Int) -> Int? {
+        trace.append("rs.int(\(index))")
+        return resultSet[currentRow][index] as? Int
+    }
+
+    func double(at index: Int) -> Double? {
         trace.append("rs.double(\(index))")
-        return resultSet[currentRow][index] as? Double ?? 0
+        return resultSet[currentRow][index] as? Double
     }
 
 }

--- a/IdentityAccess/IdentityAccessImplementations/persistence/Database.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/Database.swift
@@ -24,11 +24,13 @@ public protocol Connection {
 public protocol Statement {
 
     func set(_ value: String, at index: Int) throws
+    func set(_ value: Data, at index: Int) throws
     func set(_ value: Int, at index: Int) throws
     func set(_ value: Double, at index: Int) throws
     func setNil(at index: Int) throws
 
     func set(_ value: String, forKey key: String) throws
+    func set(_ value: Data, forKey key: String) throws
     func set(_ value: Int, forKey key: String) throws
     func set(_ value: Double, forKey key: String) throws
     func setNil(forKey key: String) throws
@@ -42,8 +44,9 @@ public protocol ResultSet {
 
     func advanceToNextRow() throws -> Bool
     func string(at index: Int) -> String?
-    func int(at index: Int) -> Int
-    func double(at index: Int) -> Double
+    func int(at index: Int) -> Int?
+    func double(at index: Int) -> Double?
+    func data(at index: Int) -> Data?
 
 }
 

--- a/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteDatabaseIntegrationTests.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteDatabaseIntegrationTests.swift
@@ -71,7 +71,7 @@ class SQLiteDatabaseIntegrationTests: XCTestCase {
         if let rs = try stmt2.execute() {
             var results = [Test]()
             while try rs.advanceToNextRow() {
-                results.append(Test(id: rs.int(at: 0), val: rs.string(at: 1) ?? "NULL"))
+                results.append(Test(id: rs.int(at: 0) ?? -1, val: rs.string(at: 1) ?? "NULL"))
             }
             XCTAssertEqual(results, [Test(id: 1, val: "test")])
         } else {

--- a/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteResultSet.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteResultSet.swift
@@ -23,6 +23,7 @@ public class SQLiteResultSet: ResultSet {
 
     public func string(at index: Int) -> String? {
         assertIndex(index)
+        guard sqlite.sqlite3_column_type(stmt, Int32(index)) != CSQLite3.SQLITE_NULL else { return nil }
         guard let cString = sqlite.sqlite3_column_text(stmt, Int32(index)) else {
             return nil
         }
@@ -32,17 +33,27 @@ public class SQLiteResultSet: ResultSet {
         }
     }
 
+    public func data(at index: Int) -> Data? {
+        assertIndex(index)
+        guard sqlite.sqlite3_column_type(stmt, Int32(index)) != CSQLite3.SQLITE_NULL else { return nil }
+        guard let ptr = sqlite.sqlite3_column_blob(stmt, Int32(index)) else { return nil }
+        let bytesCount = sqlite.sqlite3_column_bytes(stmt, Int32(index))
+        return Data(bytes: ptr, count: Int(bytesCount))
+    }
+
     private func assertIndex(_ index: Int) {
         precondition((0..<columnCount).contains(index), "Index out of column count range")
     }
 
-    public func int(at index: Int) -> Int {
+    public func int(at index: Int) -> Int? {
         assertIndex(index)
+        guard sqlite.sqlite3_column_type(stmt, Int32(index)) != CSQLite3.SQLITE_NULL else { return nil }
         return Int(sqlite.sqlite3_column_int64(stmt, Int32(index)))
     }
 
-    public func double(at index: Int) -> Double {
+    public func double(at index: Int) -> Double? {
         assertIndex(index)
+        guard sqlite.sqlite3_column_type(stmt, Int32(index)) != CSQLite3.SQLITE_NULL else { return nil }
         return sqlite.sqlite3_column_double(stmt, Int32(index))
     }
 

--- a/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteStatement.swift
+++ b/IdentityAccess/IdentityAccessImplementations/persistence/SQLiteStatement.swift
@@ -68,11 +68,26 @@ public class SQLiteStatement: Statement, Assertable {
         try assertBindSuccess(status)
     }
 
+    public func set(_ value: Data, at index: Int) throws {
+        try assertCanBind()
+        let byteCount = value.count
+        let status = value.withUnsafeBytes { ptr -> Int32 in
+            sqlite.sqlite3_bind_blob(stmt,
+                                     Int32(index),
+                                     UnsafeRawPointer(ptr),
+                                     Int32(byteCount),
+                                     CSQLite3.SQLITE_TRANSIENT)
+        }
+        try assertBindSuccess(status)
+    }
+
     public func set(_ value: Int, at index: Int) throws {
         try assertCanBind()
         let status = sqlite.sqlite3_bind_int64(stmt, Int32(index), Int64(value))
         try assertBindSuccess(status)
     }
+
+
 
     public func set(_ value: Double, at index: Int) throws {
         try assertCanBind()
@@ -87,6 +102,11 @@ public class SQLiteStatement: Statement, Assertable {
     }
 
     public func set(_ value: String, forKey key: String) throws {
+        let index = try parameterIndex(for: key)
+        try set(value, at: index)
+    }
+
+    public func set(_ value: Data, forKey key: String) throws {
         let index = try parameterIndex(for: key)
         try set(value, at: index)
     }


### PR DESCRIPTION
- Added support for `Data` values in `Statement` and `ResultSet`
- Added nillable results in `ResultSet`
- Added handling of throwable autoclosures in `Assertable`
- Added import/export to `Data` in `Gatekeeper` with `Codable` internal implementation
  - using `PropertyListEncoder/Decoder`
- Added `DBSingleGatekeeperRepository` with SQL implementation
- Added initialization of `DBSingleGatekeeperRepository` in `AppDelegate`

Important: the app must be reinstalled before use after merging this PR.