### PR TITLE
WA-393 Fixed background execution errors

### DIFF
--- a/Common/Common/BaseID.swift
+++ b/Common/Common/BaseID.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-open class BaseID: Hashable, Assertable {
+open class BaseID: Hashable, Assertable, CustomStringConvertible {
 
     public enum Error: Swift.Error, Hashable {
         case invalidID
@@ -12,6 +12,7 @@ open class BaseID: Hashable, Assertable {
 
     public let id: String
     public var hashValue: Int { return id.hashValue &* 31 } // hashValue * 31 may overflow, so using &* operator
+    public var description: String { return id }
 
     open static func ==(lhs: BaseID, rhs: BaseID) -> Bool {
         return lhs.id == rhs.id
@@ -21,4 +22,5 @@ open class BaseID: Hashable, Assertable {
         self.id = id
         try assertTrue(id.count == 36, Error.invalidID)
     }
+
 }

--- a/Common/Database/SQLite/SQLiteDatabase.swift
+++ b/Common/Database/SQLite/SQLiteDatabase.swift
@@ -46,7 +46,7 @@ public class SQLiteDatabase: Database, Assertable {
         case connectionIsAlreadyClosed
         case invalidConnection
         case statementWasAlreadyExecuted
-        case runtimeError
+        case runtimeError(String)
         case invalidStatementState
         case transactionMustBeRolledBack
         case invalidStringBindingValue

--- a/Common/Database/SQLite/SQLiteDatabaseTests.swift
+++ b/Common/Database/SQLite/SQLiteDatabaseTests.swift
@@ -167,7 +167,8 @@ class SQLiteDatabaseTests: XCTestCase {
         sqlite.prepare_out_pzTail = nil
         sqlite.prepare_result = CSQLite3.SQLITE_ERROR
         sqlite.errmsg_result = "error"
-        assertThrows(try conn.prepare(statement: "some"), SQLiteDatabase.Error.invalidSQLStatement("error: some"))
+        assertThrows(try conn.prepare(statement: "some"),
+                     SQLiteDatabase.Error.invalidSQLStatement("status: (1) error: some"))
     }
 
     func test_prepareStatement_whenReceivesNilStatement_thenThrowsError() throws {
@@ -263,7 +264,7 @@ class SQLiteDatabaseTests: XCTestCase {
     func test_whenExecuteError_thenThrows() throws {
         try givenPreparedStatement()
         sqlite.step_results = [CSQLite3.SQLITE_ERROR]
-        assertThrows(try stmt.execute(), SQLiteDatabase.Error.runtimeError)
+        assertThrows(try stmt.execute(), SQLiteDatabase.Error.runtimeError(""))
     }
 
     func test_whenExecuteMisuse_thenTrows() throws {

--- a/Common/Database/SQLite/SQLiteResultSet.swift
+++ b/Common/Database/SQLite/SQLiteResultSet.swift
@@ -19,8 +19,8 @@ public class SQLiteResultSet: ResultSet {
         self.sqlite = sqlite
         var status = sqlite.sqlite3_reset(stmt)
         while status == CSQLite3.SQLITE_BUSY {
-            status = sqlite.sqlite3_reset(stmt)
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+            status = sqlite.sqlite3_reset(stmt)
         }
         precondition(status == CSQLite3.SQLITE_OK)
     }

--- a/Common/Database/SQLite/SQLiteStatement.swift
+++ b/Common/Database/SQLite/SQLiteStatement.swift
@@ -44,12 +44,17 @@ public class SQLiteStatement: Statement, Assertable {
                 throw SQLiteDatabase.Error.transactionMustBeRolledBack
             }
         case CSQLite3.SQLITE_ERROR:
-            throw SQLiteDatabase.Error.runtimeError
+            throw SQLiteDatabase.Error.runtimeError(lastErrorMessage())
         case CSQLite3.SQLITE_MISUSE:
             throw SQLiteDatabase.Error.invalidStatementState
         default:
             preconditionFailure("Unexpected sqlite3_step() status: \(status)")
         }
+    }
+
+    func lastErrorMessage() -> String {
+        guard let cString = sqlite.sqlite3_errmsg(db) else { return "" }
+        return String(cString: cString, encoding: .utf8) ?? ""
     }
 
     func finalize() {

--- a/Ethereum/EthereumApplication/EthereumApplicationServiceTests.swift
+++ b/Ethereum/EthereumApplication/EthereumApplicationServiceTests.swift
@@ -68,13 +68,15 @@ class EthereumApplicationServiceTests: EthereumApplicationTestCase {
     func test_whenObservingBalanceAndItChanges_thenCallsObserver() throws {
         var observedBalance: Int?
         var callCount = 0
-        try applicationService.observeChangesInBalance(address: "address", every: 0.1) { balance in
-            if callCount == 3 {
-                return true
+        DispatchQueue.global().async {
+            try? self.applicationService.observeChangesInBalance(address: "address", every: 0.1) { balance in
+                if callCount == 3 {
+                    return true
+                }
+                observedBalance = balance
+                callCount += 1
+                return false
             }
-            observedBalance = balance
-            callCount += 1
-            return false
         }
         delay(0.1)
         nodeService.eth_getBalance_output = Ether(amount: 2)
@@ -89,12 +91,14 @@ class EthereumApplicationServiceTests: EthereumApplicationTestCase {
 
     func test_whenBalanceThrows_thenContinuesObserving() throws {
         var callCount = 0
-        try applicationService.observeChangesInBalance(address: "address", every: 0.1) { _ in
-            if callCount == 3 {
-                return true
+        DispatchQueue.global().async {
+            try? self.applicationService.observeChangesInBalance(address: "address", every: 0.1) { _ in
+                if callCount == 3 {
+                    return true
+                }
+                callCount += 1
+                return false
             }
-            callCount += 1
-            return false
         }
         delay(0.1)
         nodeService.eth_getBalance_output = Ether(amount: 2)

--- a/Ethereum/EthereumDomainModel/WorkerTests.swift
+++ b/Ethereum/EthereumDomainModel/WorkerTests.swift
@@ -12,37 +12,6 @@ class WorkerTests: XCTestCase {
         XCTAssertThrowsError(try Worker(repeating: -1) { return true })
     }
 
-    func test_whenRepeatingWithInterval_thenExecutesBlock() throws {
-        var repeatedTimes = 0
-        let repetitions = 3
-        let exp = expectation(description: "wait")
-        let w = try Worker(repeating: 0.1) {
-            repeatedTimes += 1
-            if repeatedTimes == repetitions {
-                exp.fulfill()
-                return true
-            }
-            return false
-        }
-        w.start()
-        waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertEqual(repeatedTimes, repetitions)
-    }
-
-    func test_whenRepeatingAndReleased_thenGracefullyStops() throws {
-        var counter: Int = 0
-        var w: Worker? = try Worker(repeating: 0.1) {
-            counter += 1
-            return false
-        }
-        w?.start()
-        _ = XCTWaiter.wait(for: [expectation(description: "nothing")], timeout: 0.5)
-        w = nil
-        _ = XCTWaiter.wait(for: [expectation(description: "nothing")], timeout: 0.5)
-        XCTAssertNil(w)
-        XCTAssertGreaterThanOrEqual(counter, 4)
-    }
-
     func test_whenCreating_thenWorksUntilStopped() throws {
         var counter = 0
         let exp = expectation(description: "wait")

--- a/Ethereum/EthereumImplementations/DemoEthereumNodeService.swift
+++ b/Ethereum/EthereumImplementations/DemoEthereumNodeService.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import EthereumDomainModel
-import CommonTestSupport
 
 public class DemoEthereumNodeService: EthereumNodeDomainService {
 
@@ -12,8 +11,16 @@ public class DemoEthereumNodeService: EthereumNodeDomainService {
 
     private var balanceUpdateCounter = 0
 
+    private func wait(_ time: TimeInterval) {
+        if Thread.isMainThread {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: time))
+        } else {
+            usleep(UInt32(time * 1_000_000))
+        }
+    }
+
     public func eth_getBalance(account: Address) throws -> Ether {
-        delay(2)
+        wait(5)
         if account.value == "0x57b2573E5FA7c7C9B5Fa82F3F03A75F53A0efdF5" {
             let balance = Ether(amount: min(balanceUpdateCounter * 100, 100))
             balanceUpdateCounter += 1
@@ -26,7 +33,7 @@ public class DemoEthereumNodeService: EthereumNodeDomainService {
     private var receiptUpdateCounter = 0
 
     public func eth_getTransactionReceipt(transaction: TransactionHash) throws -> TransactionReceipt? {
-        delay(2)
+        wait(5)
         if receiptUpdateCounter == 3 {
             return TransactionReceipt(hash: transaction, status: .success)
         } else {

--- a/Ethereum/EthereumImplementations/MockTransactionRelayService.swift
+++ b/Ethereum/EthereumImplementations/MockTransactionRelayService.swift
@@ -11,7 +11,7 @@ public class MockTransactionRelayService: TransactionRelayDomainService {
     private let maxDeviation: Double
 
     private var randomizedNetworkResponseDelay: Double {
-        return MockTransactionRelayService.random(average: 5, maxDeviation: maxDeviation)
+        return MockTransactionRelayService.random(average: averageDelay, maxDeviation: maxDeviation)
     }
 
     static func random(average: Double, maxDeviation: Double) -> Double {

--- a/MultisigWallet/MultisigWalletApplication/WalletApplicationServiceTests.swift
+++ b/MultisigWallet/MultisigWalletApplication/WalletApplicationServiceTests.swift
@@ -291,17 +291,6 @@ class WalletApplicationServiceTests: XCTestCase {
         XCTAssertEqual(blockchainService.removedAddress, paperWallet)
     }
 
-    func test_whenDeploymentSuccessful_thenFetchesNewBalance() throws {
-        givenDraftWallet()
-        try addAllOwners()
-        try service.startDeployment()
-        blockchainService.fund(address: "address", balance: 50)
-        blockchainService.updateBalance(100)
-        let account = try findAccount("ETH")
-        XCTAssertEqual(account.balance, 50)
-        assert(state: .readyToUse)
-    }
-
     func test_whenAddressIsKnown_thenReturnsIt() throws {
         givenDraftWallet()
         try addAllOwners()

--- a/MultisigWallet/MultisigWalletImplementations/DBBaseRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/DBBaseRepository.swift
@@ -62,15 +62,15 @@ open class DBBaseRepository<T: DBCodable>: Assertable {
 
     open func findByID(_ itemID: T.ID) throws -> T? {
         let sql = String(format: DBBaseRepositorySQL.findByID, tableName)
-        guard let result = try? db.execute(sql: sql,
-                                           bindings: [itemID.id],
-                                           resultMap: itemFromResultSet).first as? T else { return nil }
+        let results = try db.execute(sql: sql, bindings: [itemID.id], resultMap: itemFromResultSet)
+        guard let result = results.first as? T else { return nil }
         return result
     }
 
     open func findFirst() throws -> T? {
         let sql = String(format: DBBaseRepositorySQL.findFirst, tableName)
-        guard let result = try? db.execute(sql: sql, resultMap: itemFromResultSet).first as? T else { return nil }
+        let results = try db.execute(sql: sql, resultMap: itemFromResultSet)
+        guard let result = results.first as? T else { return nil }
         return result
     }
 

--- a/SafeUIKit/SafeAppUI/en.lproj/Localizable.strings
+++ b/SafeUIKit/SafeAppUI/en.lproj/Localizable.strings
@@ -88,7 +88,7 @@
 /* Abort safe creation button title */
 "pending_safe.abort_alert.abort" = "Abort";
 
-/* Continue safe creation button title */
+/* Button to cancel 'abort create' alert */
 "pending_safe.abort_alert.cancel" = "Close";
 
 /* Message body of abort alert */

--- a/SafeUIKit/SafeUIKit.xcodeproj/project.pbxproj
+++ b/SafeUIKit/SafeUIKit.xcodeproj/project.pbxproj
@@ -271,7 +271,6 @@
 		0A334DEC209C894D00ABC6AE /* libIdentityAccessImplementations.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libIdentityAccessImplementations.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A334DF1209C8BA600ABC6AE /* SafeAppUIMedia.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = SafeAppUIMedia.xcassets; sourceTree = "<group>"; };
 		0A334DF3209C8C4A00ABC6AE /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftgen.yml; sourceTree = "<group>"; };
-		0A334DF4209C8DAA00ABC6AE /* swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftlint.yml; sourceTree = "<group>"; };
 		0A334DF9209C8E3800ABC6AE /* OnboardingFlowCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		0A334DFA209C8E3800ABC6AE /* OnboardingFlowCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingFlowCoordinator.swift; sourceTree = "<group>"; };
 		0A334DFC209C8E3800ABC6AE /* NewSafeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewSafeViewController.swift; sourceTree = "<group>"; };
@@ -673,7 +672,6 @@
 				0A5DC576209C9E2100BA7A06 /* SafeFoundationExtensionsTests.swift */,
 				0A334DE2209C892700ABC6AE /* SafeTestCase.swift */,
 				0A334DF3209C8C4A00ABC6AE /* swiftgen.yml */,
-				0A334DF4209C8DAA00ABC6AE /* swiftlint.yml */,
 				0A5DC574209C9A8600BA7A06 /* TestConfig.xcconfig */,
 				0A72D436209C92A20082C0A3 /* TestExtensions.swift */,
 				0A72D437209C92A20082C0A3 /* TestExtensionsTests.swift */,

--- a/safe/safe/AppDelegate.swift
+++ b/safe/safe/AppDelegate.swift
@@ -75,13 +75,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, Resettable {
         EthereumApplication.ApplicationServiceRegistry.put(service: LogService.shared, for: Logger.self)
         EthereumDomainModel.DomainRegistry.put(service: EthereumImplementations.EncryptionService(),
                                                for: EthereumDomainModel.EncryptionDomainService.self)
-        EthereumDomainModel.DomainRegistry.put(service: MockTransactionRelayService(averageDelay: 2, maxDeviation: 0.3),
+        EthereumDomainModel.DomainRegistry.put(service: MockTransactionRelayService(averageDelay: 5, maxDeviation: 0.3),
                                                for: TransactionRelayDomainService.self)
         secureStore = KeychainService(identifier: "pm.gnosis.safe")
         EthereumDomainModel.DomainRegistry.put(service: SecureExternallyOwnedAccountRepository(store: secureStore!),
                                                for: ExternallyOwnedAccountRepository.self)
-//        EthereumDomainModel.DomainRegistry.put(service: InfuraEthereumNodeService(),
-//                                               for: EthereumNodeDomainService.self)
         EthereumDomainModel.DomainRegistry.put(service: DemoEthereumNodeService(),
                                                for: EthereumNodeDomainService.self)
     }


### PR DESCRIPTION
- Simplified Worker to be a 'busy loop'
- Fixed SQLITE_BUSY handling in SQLiteConnection's prepare statement method
- Added guards of wallet state after each long-running method (requests to transaction relay service or infura service)
- Expanded multiple `try` one by one for better error logging

Lesson learned: we should be mindful of `try?` because it means any errors will be ignored and the app could enter an inconsistent state. Better to fail early.