### PR TITLE
Use symlinks for git hooks

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,11 +48,14 @@ if [ ! -d $TEMPLATES_DIR ]; then
   cp -R xcode-templates/* $TEMPLATES_DIR/
 fi
 
-if [ ! -d .git/hooks ]; then
-   mkdir -p .git/hooks
-fi
+mkdir -p .git/hooks
+cd .git/hooks
+
 echo "Installing git configuration"
-cp git/hooks/* .git/hooks/
+for hook in ../../git/hooks/* ; do
+  rm -f $(basename $hook)
+  ln -sf $hook
+fi
 
 echo "Disabling git case insensitive matches"
 git config --local core.ignorecase false

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,14 +48,14 @@ if [ ! -d $TEMPLATES_DIR ]; then
   cp -R xcode-templates/* $TEMPLATES_DIR/
 fi
 
-mkdir -p .git/hooks
-cd .git/hooks
-
 echo "Installing git configuration"
+mkdir -p .git/hooks
+pushd .git/hooks
 for hook in ../../git/hooks/* ; do
   rm -f $(basename $hook)
   ln -sf $hook
 fi
+popd
 
 echo "Disabling git case insensitive matches"
 git config --local core.ignorecase false


### PR DESCRIPTION
1. `mkdir -p` could be used as an equivalent for check + create
2. Symlinks are better, as they would keep hooks updated.