### PR TITLE
Removes boilerplate initializers

### DIFF
--- a/MultisigWallet/MultisigWalletDomainModel/Ethereum/EthSignature.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Ethereum/EthSignature.swift
@@ -11,10 +11,4 @@ public struct EthSignature: Codable, Equatable {
     public var s: String
     public var v: Int
 
-    public init(r: String, s: String, v: Int) {
-        self.r = r
-        self.s = s
-        self.v = v
-    }
-
 }

--- a/MultisigWallet/MultisigWalletDomainModel/Ethereum/ExternallyOwnedAccount.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Ethereum/ExternallyOwnedAccount.swift
@@ -85,13 +85,6 @@ public struct Mnemonic: Equatable {
     /// words of the mnemonic phrase
     public let words: [String]
 
-    /// Creates new mnemonic with words
-    ///
-    /// - Parameter words: words of the mnemonic
-    public init(words: [String]) {
-        self.words = words
-    }
-
 }
 
 /// Private key data structure
@@ -99,20 +92,12 @@ public struct PrivateKey: Equatable {
 
     public let data: Data
 
-    public init(data: Data) {
-        self.data = data
-    }
-
 }
 
 /// Public key data structure
 public struct PublicKey: Equatable {
 
     public let data: Data
-
-    public init(data: Data) {
-        self.data = data
-    }
 
 }
 


### PR DESCRIPTION
Compiler generates boilerplate initializers.
There's no harm to have them in code.
But when reading code I find myself stumble for a moment to figure out is code really doing something different then default generated initializer.