### PR TITLE
Makes storage of WalletIDList fileprivate

### DIFF
--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/WalletIDList.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/WalletIDList.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public struct WalletIDList: Equatable {
 
-    var storage: [WalletID]
+    fileprivate var storage: [WalletID]
 
     public init() {
         self.init([])


### PR DESCRIPTION
Actually I didn't get the idea calling it a list and adopting RandomAccessCollection.
Nonetheless, storage better to be private.