### PR TITLE
Implements hash(into:) for conforming to Hashable

### DIFF
--- a/Common/Common/BaseID.swift
+++ b/Common/Common/BaseID.swift
@@ -26,7 +26,11 @@ open class BaseID: Hashable, Assertable, CustomStringConvertible {
     }
 
     public let id: String
-    public var hashValue: Int { return id.hashValue &* 31 } // hashValue * 31 may overflow, so using &* operator
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
     public var description: String { return id }
 
     public static func ==(lhs: BaseID, rhs: BaseID) -> Bool {

--- a/Common/Common/IdentifiableEntity.swift
+++ b/Common/Common/IdentifiableEntity.swift
@@ -8,7 +8,10 @@ import Foundation
 open class IdentifiableEntity<T: Hashable>: Hashable, Assertable {
 
     public let id: T
-    public var hashValue: Int { return id.hashValue }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 
     public static func ==(lhs: IdentifiableEntity<T>, rhs: IdentifiableEntity<T>) -> Bool {
         return lhs.id == rhs.id

--- a/Common/Common/TokenData.swift
+++ b/Common/Common/TokenData.swift
@@ -31,8 +31,8 @@ public struct TokenData: Equatable, Hashable {
         self.balance = balance
     }
 
-    public var hashValue: Int {
-        return address.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(address)
     }
 
     public var isEther: Bool {


### PR DESCRIPTION
Implements recommended hash(into:) instead of legacy hashValue for conforming to Hashable