### PR TITLE
GH-862 added error logging for client request errors

### DIFF
--- a/Common/Common/JSONHTTPClient.swift
+++ b/Common/Common/JSONHTTPClient.swift
@@ -129,8 +129,11 @@ public class JSONHTTPClient {
         var data = result.data ?? Data()
 
         if (400...499).contains(httpResponse.statusCode) {
+            let requestBody = request.httpBody == nil ? "<null>" :
+                (String(data: request.httpBody!, encoding: .utf8) ?? "<empty>")
             let userInfo: [String: Any] = [NSLocalizedDescriptionKey: "URL request client error",
                                            "request": request,
+                                           "requestBody": requestBody,
                                            "response": httpResponse,
                                            "responseBody": String(data: data, encoding: .utf8) ?? "<empty>"]
             let error = NSError(domain: "JSONHTTPClient", code: httpResponse.statusCode, userInfo: userInfo)


### PR DESCRIPTION
closes #862 

Adds logging of all client HTTP errors (4xx) so that we know about situations when app submits invalid requests (signatures, or any other information).

If it becomes too verbose, we'll adjust it in the next release.