### PR TITLE
GH-934 implemented raw call to ethereum node

### DIFF
--- a/Common/Common.xcodeproj/project.pbxproj
+++ b/Common/Common.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		0AD0779E21A2D35500DF1757 /* FileSystemGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0779D21A2D35500DF1757 /* FileSystemGuardTests.swift */; };
 		0AD077A021A2F3DE00DF1757 /* DataProtectionAwareCSQLite3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0779F21A2F3DE00DF1757 /* DataProtectionAwareCSQLite3.swift */; };
 		0AD1D1E421A8482800941EA1 /* Data+Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD1D1E321A8482800941EA1 /* Data+Padding.swift */; };
+		0ADE03DD22DDC29E00CA4705 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADE03DC22DDC29E00CA4705 /* HTTPClient.swift */; };
 		0AEF8A2C20A0814F006A1265 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AEF8A2B20A0814F006A1265 /* libsqlite3.tbd */; };
 		0AF4F50C225CEDB00051F68B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AF4F50A225CEDB00051F68B /* LaunchScreen.storyboard */; };
 		0AF4F50D225CEDB00051F68B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AF4F50B225CEDB00051F68B /* Main.storyboard */; };
@@ -255,6 +256,7 @@
 		0AD0779D21A2D35500DF1757 /* FileSystemGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemGuardTests.swift; sourceTree = "<group>"; };
 		0AD0779F21A2F3DE00DF1757 /* DataProtectionAwareCSQLite3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProtectionAwareCSQLite3.swift; sourceTree = "<group>"; };
 		0AD1D1E321A8482800941EA1 /* Data+Padding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Padding.swift"; sourceTree = "<group>"; };
+		0ADE03DC22DDC29E00CA4705 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		0AEF8A2B20A0814F006A1265 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		0AF4F50A225CEDB00051F68B /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0AF4F50B225CEDB00051F68B /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 				0AFFF41620809D040030200C /* FoundationExtensionsTests.swift */,
 				0AFFF44A2084FB540030200C /* IdentifiableEntity.swift */,
 				555C94C720E52B7900A0621D /* JSONHTTPClient.swift */,
+				0ADE03DC22DDC29E00CA4705 /* HTTPClient.swift */,
 				0A3FADEF207B504F00F0D214 /* Tests-Info.plist */,
 				0A934D2F20B703E400F15616 /* SecureStore.swift */,
 				0A042E1320B818A900F5C885 /* InMemorySecureStore.swift */,
@@ -887,6 +890,7 @@
 				55327B672226935700277B15 /* Tracker.swift in Sources */,
 				0AFFF41520809BBE0030200C /* Assertable.swift in Sources */,
 				0AD1D1E421A8482800941EA1 /* Data+Padding.swift in Sources */,
+				0ADE03DD22DDC29E00CA4705 /* HTTPClient.swift in Sources */,
 				55126B7221AD75D300A9F810 /* OneOperationWaitingScheduler.swift in Sources */,
 				0AB0B565216384C200FB2435 /* TokenData.swift in Sources */,
 				0AFFF4492084FB3D0030200C /* BaseID.swift in Sources */,

--- a/Common/Common/HTTPClient.swift
+++ b/Common/Common/HTTPClient.swift
@@ -1,0 +1,112 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+public protocol HTTPRequest {
+
+    var httpMethod: String { get }
+    var urlPath: String { get }
+    var query: String? { get }
+    var body: Data? { get }
+    var headers: [String: String] { get }
+
+}
+
+public extension HTTPRequest {
+
+    var query: String? { return nil }
+    var body: Data? { return nil }
+    var headers: [String: String] { return [:] }
+
+}
+
+/// Synchronous http client
+public class HTTPClient {
+
+    /// Client error
+    ///
+    /// - networkRequestFailed: network request failed for some reason. Provided are request, response and data values.
+    public enum Error: Swift.Error {
+        case networkRequestFailed(URLRequest, URLResponse?, Data?)
+    }
+
+    private typealias URLDataTaskResult = (data: Data?, response: URLResponse?, error: Swift.Error?)
+
+    private let baseURL: URL
+    private let logger: Logger?
+
+    /// Creates new client with baseURL and logger
+    ///
+    /// - Parameters:
+    ///   - url: base url for creating all request urls
+    ///   - logger: logger for debugging and error purposes
+    public init(url: URL, logger: Logger? = nil) {
+        baseURL = url
+        self.logger = logger
+    }
+
+    /// Executes request and returns server response. The call is synchronous.
+    ///
+    /// - Parameter request: a request to send
+    /// - Returns: response
+    /// - Throws:
+    ///     - `HTTPClient.Error.networkRequestFailed` in case request fails
+    ///     - Network errors are rethrown (URLSession errors, for example)
+    @discardableResult
+    public func execute<T: HTTPRequest>(request: T) throws -> Data {
+        logger?.debug("Preparing to send \(request)")
+        let urlRequest = try self.urlRequest(from: request)
+        let result = send(urlRequest)
+        return try self.response(from: urlRequest, result: result)
+    }
+
+    private func urlRequest<T: HTTPRequest>(from request: T) throws -> URLRequest {
+        var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        urlComponents.path = request.urlPath
+        urlComponents.query = request.query
+        var urlRequest = URLRequest(url: urlComponents.url!)
+        urlRequest.httpMethod = request.httpMethod
+        if request.httpMethod != "GET" {
+            urlRequest.httpBody = request.body
+            if let str = String(data: urlRequest.httpBody!, encoding: .utf8) {
+                logger?.debug(str)
+            }
+            request.headers.forEach { header, value in
+                urlRequest.setValue(value, forHTTPHeaderField: header)
+            }
+        }
+        return urlRequest
+    }
+
+    private func send(_ request: URLRequest) -> URLDataTaskResult {
+        var result: URLDataTaskResult!
+        let semaphore = DispatchSemaphore(value: 0)
+        logger?.debug("Sending request \(request)")
+
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
+            result = (data, response, error)
+            semaphore.signal()
+        }
+        dataTask.resume()
+        semaphore.wait()
+        logger?.debug("Received response \(result!)")
+        return result
+    }
+
+    private func response(from request: URLRequest, result: URLDataTaskResult) throws -> Data {
+        if let data = result.data, let rawResponse = String(data: data, encoding: .utf8) {
+            logger?.debug(rawResponse)
+        }
+        if let error = result.error {
+            throw error
+        }
+        guard let httpResponse = result.response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode),
+            let data = result.data else {
+                throw Error.networkRequestFailed(request, result.response, result.data)
+        }
+        return data
+    }
+
+}

--- a/MultisigWallet/MultisigWalletApplication/EthereumApplicationService.swift
+++ b/MultisigWallet/MultisigWalletApplication/EthereumApplicationService.swift
@@ -88,7 +88,7 @@ open class EthereumApplicationService: Assertable {
             return try block()
         } catch let error as NetworkServiceError {
             throw self.error(from: error)
-        } catch let JSONHTTPClient.Error.networkRequestFailed(_, response, _) {
+        } catch let HTTPClient.Error.networkRequestFailed(_, response, _) {
             throw self.error(from: response)
         }
     }
@@ -122,7 +122,7 @@ open class EthereumApplicationService: Assertable {
             return try block()
         } catch let error as NetworkServiceError {
             throw self.error(from: error)
-        } catch let JSONHTTPClient.Error.networkRequestFailed(_, response, _) {
+        } catch let HTTPClient.Error.networkRequestFailed(_, response, _) {
             throw self.error(from: response)
         }
     }

--- a/MultisigWallet/MultisigWalletApplication/WalletApplicationService.swift
+++ b/MultisigWallet/MultisigWalletApplication/WalletApplicationService.swift
@@ -208,7 +208,7 @@ public class WalletApplicationService: Assertable {
             return try block()
         } catch NotificationDomainServiceError.validationFailed {
             throw WalletApplicationServiceError.validationFailed
-        } catch let JSONHTTPClient.Error.networkRequestFailed(request, response, data) {
+        } catch let HTTPClient.Error.networkRequestFailed(request, response, data) {
             logNetworkError(request, response, data)
             if let data = data, let dataStr = String(data: data, encoding: .utf8),
                 dataStr.range(of: "Exceeded expiration date") != nil {
@@ -227,7 +227,7 @@ public class WalletApplicationService: Assertable {
             return try block()
         } catch let error as NetworkServiceError {
             throw self.error(from: error)
-        } catch let JSONHTTPClient.Error.networkRequestFailed(request, response, data) {
+        } catch let HTTPClient.Error.networkRequestFailed(request, response, data) {
             logNetworkError(request, response, data)
             throw self.error(from: response)
         }

--- a/MultisigWallet/MultisigWalletDomainModel/NotificationService/MockNotificationService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/NotificationService/MockNotificationService.swift
@@ -36,7 +36,7 @@ public final class MockNotificationService: NotificationDomainService {
 
     private func throwIfNeeded() throws {
         if shouldThrowNetworkError {
-            throw JSONHTTPClient.Error.networkRequestFailed(URLRequest(url: URL(string: "http://test.url")!), nil, nil)
+            throw HTTPClient.Error.networkRequestFailed(URLRequest(url: URL(string: "http://test.url")!), nil, nil)
         }
         if shouldThrowValidationFailedError {
             throw NotificationDomainServiceError.validationFailed

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/RecoveryDomainService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/RecoveryDomainService.swift
@@ -443,7 +443,7 @@ public struct WalletScheme: Equatable, CustomStringConvertible {
 }
 
 fileprivate func serviceError(from error: Error) -> Error {
-    guard case let JSONHTTPClient.Error.networkRequestFailed(_, response, _) = error else { return error }
+    guard case let HTTPClient.Error.networkRequestFailed(_, response, _) = error else { return error }
     guard let httpResponse = response as? HTTPURLResponse else { return error }
     switch httpResponse.statusCode {
     case 400: return RecoveryServiceError.failedToCreateValidTransactionData

--- a/MultisigWallet/MultisigWalletImplementations/Services/MockTransactionRelayService.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Services/MockTransactionRelayService.swift
@@ -70,7 +70,7 @@ public class MockTransactionRelayService: TransactionRelayDomainService {
 
     private func throwIfNeeded() throws {
         if shouldThrowNetworkError {
-            throw JSONHTTPClient.Error.networkRequestFailed(URLRequest(url: URL(string: "http://test.url")!), nil, nil)
+            throw HTTPClient.Error.networkRequestFailed(URLRequest(url: URL(string: "http://test.url")!), nil, nil)
         }
         if shouldThrow { throw TestError.error }
     }

--- a/safe/safe/IntegrationTests/HTTPNotificatonServiceTests.swift
+++ b/safe/safe/IntegrationTests/HTTPNotificatonServiceTests.swift
@@ -38,7 +38,7 @@ class HTTPNotificatonServiceTests: XCTestCase {
         do {
             try notificationService.pair(pairingRequest: pairingRequest)
             XCTFail("Pairing call should faild for expired browser extension")
-        } catch let e as JSONHTTPClient.Error {
+        } catch let e as HTTPClient.Error {
             switch e {
             case let .networkRequestFailed(_, response, data):
                 XCTAssertNotNil(response)

--- a/safe/safe/IntegrationTests/InfuraEthereumNodeServiceTests.swift
+++ b/safe/safe/IntegrationTests/InfuraEthereumNodeServiceTests.swift
@@ -123,6 +123,17 @@ class InfuraEthereumNodeServiceTests: BlockchainIntegrationTest {
         XCTAssertEqual(try proxy.getThreshold(), 2)
     }
 
+    func test_rawCall() throws {
+        let payload = """
+{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0xe8"],"id":1}
+"""
+        let expectedResponse = """
+{"jsonrpc":"2.0","id":1,"result":"0x0"}
+"""
+        let response = try service.rawCall(payload: payload)
+        XCTAssertEqual(response, expectedResponse)
+    }
+
 }
 
 struct SafeContractInfo {


### PR DESCRIPTION
- Re-using JSONHTTPClient as is was not possible because raw string conversion to-from Swift classes based on JSONEncoder and JSONDecoder do not allow it.
- I extracted the HTTPClient class that deals with more generic request types and returns "Data" as a response.
- Added a simple integration test demonstrating that the call to Infura API node is successful.