### PR TITLE
GH-935

### DIFF
--- a/MultisigWallet/MultisigWalletApplication/WalletApplicationServiceError.swift
+++ b/MultisigWallet/MultisigWalletApplication/WalletApplicationServiceError.swift
@@ -10,5 +10,6 @@ public enum WalletApplicationServiceError: String, Swift.Error, Hashable {
     case clientError
     case serverError
     case validationFailed
+    case failedToSignTransactionByDevice
     case exceededExpirationDate
 }

--- a/MultisigWallet/MultisigWalletDomainModel/NotificationService/Messaging/CommunicationDomainService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/NotificationService/Messaging/CommunicationDomainService.swift
@@ -6,12 +6,18 @@ import Foundation
 
 public class CommunicationDomainService {
 
+    enum CommunicationError: String, Error {
+        case signingNotAvailable
+    }
+
     public init() {}
 
     public func deletePair(walletID: WalletID, other address: String) throws {
         let wallet = DomainRegistry.walletRepository.find(id: walletID)!
         let deviceOwnerAddress = wallet.owner(role: .thisDevice)!.address
-        guard let eoa = DomainRegistry.externallyOwnedAccountRepository.find(by: deviceOwnerAddress) else { return }
+        guard let eoa = DomainRegistry.externallyOwnedAccountRepository.find(by: deviceOwnerAddress) else {
+            throw CommunicationError.signingNotAvailable
+        }
         let signature = DomainRegistry.encryptionService.sign(message: "GNO" + address, privateKey: eoa.privateKey)
         let request = DeletePairRequest(device: address, signature: signature)
         try DomainRegistry.notificationService.deletePair(request: request)

--- a/MultisigWallet/MultisigWalletDomainModel/NotificationService/Messaging/CommunicationDomainService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/NotificationService/Messaging/CommunicationDomainService.swift
@@ -11,7 +11,7 @@ public class CommunicationDomainService {
     public func deletePair(walletID: WalletID, other address: String) throws {
         let wallet = DomainRegistry.walletRepository.find(id: walletID)!
         let deviceOwnerAddress = wallet.owner(role: .thisDevice)!.address
-        let eoa = DomainRegistry.externallyOwnedAccountRepository.find(by: deviceOwnerAddress)!
+        guard let eoa = DomainRegistry.externallyOwnedAccountRepository.find(by: deviceOwnerAddress) else { return }
         let signature = DomainRegistry.encryptionService.sign(message: "GNO" + address, privateKey: eoa.privateKey)
         let request = DeletePairRequest(device: address, signature: signature)
         try DomainRegistry.notificationService.deletePair(request: request)

--- a/SafeUIKit/SafeAppUI/ErrorHandler.swift
+++ b/SafeUIKit/SafeAppUI/ErrorHandler.swift
@@ -89,6 +89,8 @@ extension WalletApplicationServiceError: LocalizedError {
             return LocalizedString("ios_error_generic_client", comment: "Application submitted invalid request.")
         case .serverError:
             return LocalizedString("ios_error_generic_server", comment: "Server returned error response.")
+        case .failedToSignTransactionByDevice:
+            return LocalizedString("ios_error_failed_to_sign_transaction", comment: "Failed to sign. Try again.")
         }
     }
 

--- a/SafeUIKit/SafeAppUI/en.lproj/Localizable.strings
+++ b/SafeUIKit/SafeAppUI/en.lproj/Localizable.strings
@@ -223,6 +223,9 @@
 /* Browser extension code is expired. */
 "ios_error_extension_expired" = "Browser extension code is expired. Please, try again.";
 
+/* Failed to sign. Try again. */
+"ios_error_failed_to_sign_transaction" = "Failed to sign the transaction.Try again.";
+
 /* Application submitted invalid request. */
 "ios_error_generic_client" = "Application submitted invalid request to the server. Try again later.";
 


### PR DESCRIPTION
closes #935 

There are other places throughout the codebase where we force-unwrap the eoa from `find()` method. I keep them as is until further crashes appear.