### PR TITLE
GH-1094 Extended deployment domain service for multiple wallets

### DIFF
--- a/MultisigWallet/CommonTests/InMemoryWalletRepository.swift
+++ b/MultisigWallet/CommonTests/InMemoryWalletRepository.swift
@@ -12,4 +12,8 @@ open class InMemoryWalletRepository: BaseInMemoryRepository<Wallet, WalletID>, W
         return WalletID()
     }
 
+    public func filter(by states: Set<WalletState.State>) -> [Wallet] {
+        return all().filter { states.contains($0.state.state) }
+    }
+
 }

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/DeploymentDomainService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/DeploymentDomainService.swift
@@ -14,54 +14,28 @@ public class DeploymentDomainService {
     internal var responseValidator = SafeCreationResponseValidator()
     private let repeaters = Repeaters()
 
-    // Thread-safe repeaters array operations
-    private class Repeaters {
-
-        var repeaters: [Repeater] = []
-        private let queue = DispatchQueue(label: "DeploymentServiceRepeaterManagementQueue")
-
-        func add(_ repeater: Repeater) {
-            queue.async { [weak self] in
-                guard let `self` = self else { return }
-                self.repeaters.append(repeater)
-            }
-        }
-
-        func stop(_ repeater: Repeater) {
-            repeater.stop()
-            queue.async { [weak self] in
-                guard let `self` = self else { return }
-                self.repeaters.removeAll { $0 === repeater }
-            }
-        }
-
-        func stopAll() {
-            queue.async { [weak self] in
-                guard let `self` = self else { return }
-                self.repeaters.forEach { $0.stop() }
-                self.repeaters = []
-            }
-        }
-
-    }
-
     public init(_ config: DeploymentDomainServiceConfiguration = .standard) {
         self.config = config
     }
 
     public func start() {
-        DomainRegistry.eventPublisher.unsubscribe(self)
-        DomainRegistry.eventPublisher.subscribe(self, deploymentStarted)
-        DomainRegistry.eventPublisher.subscribe(self, waitingForFirstDeposit)
-        DomainRegistry.eventPublisher.subscribe(self, waitingForRemainingAmount)
-        DomainRegistry.eventPublisher.subscribe(self, walletFunded)
-        DomainRegistry.eventPublisher.subscribe(self, creationStarted)
-        DomainRegistry.eventPublisher.subscribe(self, walletCreated)
-        DomainRegistry.eventPublisher.subscribe(self, creationFailed)
-        DomainRegistry.eventPublisher.subscribe(self, deploymentAborted)
+        repeaters.stopAll() // to prevent spawning too many active threads waiting for wallet deployment
 
-        let wallet = DomainRegistry.walletRepository.selectedWallet()!
-        wallet.resume()
+        DomainRegistry.eventPublisher.unsubscribe(self)
+
+        subscribe(event: DeploymentStarted.self,                    action: prepareSafeCreationTransaction)
+        subscribe(event: StartedWaitingForFirstDeposit.self,        action: waitForFirstDeposit)
+        subscribe(event: StartedWaitingForRemainingFeeAmount.self,  action: waitForRemainingFeeAmount)
+        subscribe(event: DeploymentFunded.self,                     action: startSafeCreation)
+        subscribe(event: CreationStarted.self,                      action: waitUntilWalletIsReady)
+        subscribe(event: WalletCreated.self,                        action: postProcessCreation)
+        subscribe(event: WalletCreationFailed.self,                 action: crashTheApp)
+        subscribe(event: DeploymentAborted.self,                    action: stopAllWalletDeploymentActivity)
+
+        let walletsToCreate = DomainRegistry.walletRepository.filter(by: WalletState.State.creationStates)
+        for wallet in walletsToCreate {
+            wallet.resume()
+        }
     }
 
     public func createNewDraftWallet() {
@@ -83,172 +57,132 @@ public class DeploymentDomainService {
         WalletDomainService.recreateOwners()
     }
 
-    func deploymentStarted(_ event: DeploymentStarted) {
-        handleError { wallet in
-            let owners = wallet.allOwners().map { $0.address }
-            let request = SafeCreationRequest(saltNonce: DomainRegistry.encryptionService.randomSaltNonce(),
-                                              owners: owners,
-                                              confirmationCount: wallet.confirmationCount,
-                                              paymentToken: wallet.feePaymentTokenAddress ?? Token.Ether.address)
-            let response = try DomainRegistry.transactionRelayService.createSafeCreationTransaction(request: request)
-            try responseValidator.validate(response, request: request)
-            wallet.changeAddress(response.safeAddress)
-            wallet.updateMinimumTransactionAmount(response.payment.value)
-            wallet.changeMasterCopy(response.masterCopyAddress)
-            let version = DomainRegistry.safeContractMetadataRepository.version(masterCopyAddress:
-                response.masterCopyAddress)
-            wallet.changeContractVersion(version)
-            wallet.proceed()
-        }
-    }
+    // MARK: -  Wallet Creation Stages
 
-    func deploymentAborted(_ event: DeploymentAborted) {
-        repeaters.stopAll()
-    }
-
-    func waitingForFirstDeposit(_ event: StartedWaitingForFirstDeposit) {
-        handleError { wallet in
-            try waitForFirstDeposit(wallet)
-        }
-    }
-
-    private func waitForFirstDeposit(_ wallet: Wallet) throws {
-        try self.repeat(delay: config.balance.repeatDelay) { [unowned self] repeater in
-            guard wallet.isWaitingForFirstDeposit else { return }
-            let balance = try self.updateBalance(for: wallet)
-            guard balance > 0 else { return }
-            self.repeaters.stop(repeater)
-            wallet.proceed()
-        }
-    }
-
-    func waitingForRemainingAmount(_ event: StartedWaitingForRemainingFeeAmount) {
-        handleError { wallet in
-            try waitForFunding(wallet)
-        }
-    }
-
-    private func waitForFunding(_ wallet: Wallet) throws {
-        try self.repeat(delay: config.balance.repeatDelay) { [unowned self] repeater in
-            guard wallet.isWaitingForFunding else { return }
-            let balance = try self.updateBalance(for: wallet)
-            guard balance >= wallet.minimumDeploymentTransactionAmount else { return }
-            self.repeaters.stop(repeater)
-            wallet.proceed()
-        }
-    }
-
-    private func updateBalance(for wallet: Wallet) throws -> TokenInt {
-        let token = wallet.feePaymentTokenAddress ?? Token.Ether.address
-        let balance = try self.balance(of: wallet.address, for: token)
-        let accountID = AccountID(tokenID: TokenID(token.value), walletID: wallet.id)
-        let account = DomainRegistry.accountRepository.find(id: accountID)!
-        account.update(newAmount: balance)
-        DomainRegistry.accountRepository.save(account)
-        return balance
-    }
-
-    private func `repeat`(delay: TimeInterval, closure: @escaping (Repeater) throws -> Void) throws {
-        let repeater = Repeater(delay: delay) { [unowned self] repeater in
-            let wallet = DomainRegistry.walletRepository.selectedWallet()!
-            if self.walletAlreadyCreated(wallet) {
-                self.forceFinalizeDeployment(wallet)
-                return
-            }
-            try closure(repeater)
-        }
-        repeaters.add(repeater)
-        try repeater.start()
-    }
-
-    private func walletAlreadyCreated(_ wallet: Wallet) -> Bool {
-        do {
-            return try DomainRegistry.transactionRelayService
-                .safeCreationTransactionBlock(address: wallet.address) != nil
-        } catch {
-            return false
-        }
-    }
-
-    private func forceFinalizeDeployment(_ wallet: Wallet) {
-        repeaters.stopAll()
-        wallet.state = wallet.finalizingDeploymentState
+    func prepareSafeCreationTransaction(_ wallet: Wallet) throws {
+        let owners = wallet.allOwners().map { $0.address }
+        let request = SafeCreationRequest(saltNonce: DomainRegistry.encryptionService.randomSaltNonce(),
+                                          owners: owners,
+                                          confirmationCount: wallet.confirmationCount,
+                                          paymentToken: wallet.feePaymentTokenAddress ?? Token.Ether.address)
+        let response = try DomainRegistry.transactionRelayService.createSafeCreationTransaction(request: request)
+        try responseValidator.validate(response, request: request)
+        wallet.changeAddress(response.safeAddress)
+        wallet.updateMinimumTransactionAmount(response.payment.value)
+        wallet.changeMasterCopy(response.masterCopyAddress)
+        let version = DomainRegistry.safeContractMetadataRepository.version(masterCopyAddress:
+            response.masterCopyAddress)
+        wallet.changeContractVersion(version)
         wallet.proceed()
     }
 
-    func walletFunded(_ event: DeploymentFunded) {
-        handleError { wallet in
-            try DomainRegistry.transactionRelayService.startSafeCreation(address: wallet.address)
+    func waitForFirstDeposit(_ wallet: Wallet) throws {
+        try `repeat`(for: wallet, delay: config.balance.repeatDelay, closure: checkDidReceiveFirstDeposit)
+    }
+
+    func checkDidReceiveFirstDeposit(_ wallet: Wallet) throws -> Bool {
+        guard wallet.isWaitingForFirstDeposit else { return false }
+        let balance = try self.updateBalance(for: wallet)
+        let hasDeposit = balance > 0
+        if hasDeposit {
             wallet.proceed()
         }
+        return hasDeposit
     }
 
-    func creationStarted(_ event: CreationStarted) {
-        handleError { wallet in
-            synchronise()
-            try waitForCreationTransactionHash(wallet)
-            guard !wallet.isReadyToUse else { return }
-            try waitForCreationTransactionCompletion(wallet)
-        }
+    private func waitForRemainingFeeAmount(_ wallet: Wallet) throws {
+        try `repeat`(for: wallet, delay: config.balance.repeatDelay, closure: checkHasMinimumAmount)
     }
 
-    private func synchronise() {
-        DispatchQueue.global().async {
-            DomainRegistry.syncService.syncTokensAndAccountsOnce()
+    func checkHasMinimumAmount(_ wallet: Wallet) throws -> Bool {
+        guard wallet.isWaitingForFunding else { return false }
+        let balance = try self.updateBalance(for: wallet)
+        let hasEnough = balance >= wallet.minimumDeploymentTransactionAmount
+        if hasEnough {
+            wallet.proceed()
         }
+        return hasEnough
     }
 
-    private func waitForCreationTransactionHash(_ wallet: Wallet) throws {
-        guard wallet.creationTransactionHash == nil else {
-            DomainRegistry.eventPublisher.publish(WalletTransactionHashIsKnown())
-            return
-        }
-        try self.repeat(delay: config.deploymentStatus.repeatDelay) { [unowned self] repeater in
-            guard wallet.isFinalizingDeployment else { return }
-            guard let hash = try self.transactionHash(of: wallet.address) else { return }
-            wallet.assignCreationTransaction(hash: hash.value)
-            self.repeaters.stop(repeater)
-            DomainRegistry.walletRepository.save(wallet)
-            DomainRegistry.eventPublisher.publish(WalletTransactionHashIsKnown())
-        }
+    func startSafeCreation(_ wallet: Wallet) throws {
+        try DomainRegistry.transactionRelayService.startSafeCreation(address: wallet.address)
+        wallet.proceed()
     }
 
-    private func waitForCreationTransactionCompletion(_ wallet: Wallet) throws {
-        try self.repeat(delay: config.transactionStatus.repeatDelay) { [unowned self] repeater in
-            guard wallet.isFinalizingDeployment else { return }
-            guard let receipt = try self.receipt(of: TransactionHash(wallet.creationTransactionHash)) else { return }
-            self.repeaters.stop(repeater)
-            if receipt.status == .success {
-                wallet.proceed()
-            } else {
-                let userInfo: [String: Any] = [NSLocalizedDescriptionKey: "Creation transaction failed"]
-                let error = NSError(domain: "DeploymentDomainService", code: -1, userInfo: userInfo)
-                DomainRegistry.logger.error("Wallet creation transaction failed", error: error)
-                wallet.cancel()
-            }
+    func waitUntilWalletIsReady(_ wallet: Wallet) throws {
+        DispatchQueue.global().async(execute: DomainRegistry.syncService.syncTokensAndAccountsOnce)
+
+        if wallet.creationTransactionHash != nil {
+            DomainRegistry.eventPublisher.publish(WalletTransactionHashIsKnown(wallet))
+        } else {
+            try `repeat`(for: wallet, delay: config.deploymentStatus.repeatDelay, closure: checkHasSubmittedTransaction)
         }
+
+        if wallet.isReadyToUse { return }
+
+        try `repeat`(for: wallet, delay: config.transactionStatus.repeatDelay, closure: checkHasMinedTransaction)
     }
 
-    func walletCreated(_ event: WalletCreated) {
-        handleError { wallet in
-            try notifyDidCreate(wallet)
-            DomainRegistry.externallyOwnedAccountRepository.remove(address:
-                wallet.owner(role: .paperWallet)!.address)
-            DomainRegistry.externallyOwnedAccountRepository.remove(address:
-                wallet.owner(role: .paperWalletDerived)!.address)
-        }
+    func checkHasSubmittedTransaction(_ wallet: Wallet) throws -> Bool {
+        guard wallet.isFinalizingDeployment else { return false }
+        guard let hash = try self.transactionHash(of: wallet.address) else { return false }
+        wallet.assignCreationTransaction(hash: hash.value)
+        DomainRegistry.walletRepository.save(wallet)
+        DomainRegistry.eventPublisher.publish(WalletTransactionHashIsKnown(wallet))
+        return true
     }
 
-    private func notifyDidCreate(_ wallet: Wallet) throws {
+    func checkHasMinedTransaction(_ wallet: Wallet) throws -> Bool {
+        guard wallet.isFinalizingDeployment else { return false }
+        guard let receipt = try self.receipt(of: TransactionHash(wallet.creationTransactionHash)) else { return false }
+        if receipt.status == .success {
+            wallet.proceed()
+        } else {
+            let userInfo: [String: Any] = [NSLocalizedDescriptionKey: "Creation transaction failed"]
+            let error = NSError(domain: "DeploymentDomainService", code: -1, userInfo: userInfo)
+            DomainRegistry.logger.error("Wallet creation transaction failed", error: error)
+            wallet.cancel()
+        }
+        return true
+    }
+
+    func postProcessCreation(_ wallet: Wallet) throws {
         try DomainRegistry.communicationService.notifyWalletCreatedIfNeeded(walletID: wallet.id)
+        let paperWalletAddress = wallet.owner(role: .paperWallet)!.address
+        let derivedAddress = wallet.owner(role: .paperWalletDerived)!.address
+        DomainRegistry.externallyOwnedAccountRepository.remove(address: paperWalletAddress)
+        DomainRegistry.externallyOwnedAccountRepository.remove(address: derivedAddress)
     }
 
-    func creationFailed(_ event: WalletCreationFailed) {
+    func crashTheApp(_ wallet: Wallet) throws {
+        // should we still crash the app if the wallet failed? probably not.
+        // what then? then we should notify the user of it and ask to contact us.
         DomainRegistry.system.exit(EXIT_FAILURE)
     }
 
-    private func handleError(_ closure: (Wallet) throws -> Void) {
-        let wallet = DomainRegistry.walletRepository.selectedWallet()!
+    func stopAllWalletDeploymentActivity(_ wallet: Wallet) throws {
+        repeaters.stopAll(for: wallet.id)
+    }
+
+    // MARK: - Helper Functions
+
+    /// Assigns a handler to a wallet event of certain type
+    private func subscribe<T: WalletEvent>(event: T.Type, action: @escaping (Wallet) throws -> Void) {
+        DomainRegistry.eventPublisher.subscribe(self, bind(event, action))
+    }
+
+    /// Wrapper for a wallet event handler
+    private func bind<T: WalletEvent>(_ event: T.Type, _ action: @escaping (Wallet) throws -> Void) -> (T) -> Void {
+        return { [unowned self] event in
+            self.executeInWallet(for: event, action)
+        }
+    }
+
+    /// Fetches a wallet for the event and executes a closure. Handles errors arrising from the closure.
+    /// For an error that is not a NetworkServiceError, or a NSURLErrorDomain, the wallet deployment will be cancelled.
+    /// This would trigger the "DeploymentAborted" event implicitly through the change of wallet state.
+    func executeInWallet(for event: WalletEvent, _ closure: (Wallet) throws -> Void) {
+        let wallet = DomainRegistry.walletRepository.find(id: event.walletID)!
         do {
             try closure(wallet)
         } catch let error {
@@ -271,31 +205,70 @@ public class DeploymentDomainService {
         }
     }
 
+    /// Repeats a closure indefinitely with a delay between repetitions until the repeater is explicitly stopped.
+    /// Before each repetition checks that wallet is not yet created. Otherwise it will force-finalize wallet deployment.
+    func `repeat`(for wallet: Wallet, delay: TimeInterval, closure checkShouldStop: @escaping (Wallet) throws -> Bool) throws {
+        let repeater = Repeater(delay: delay) { [unowned self] repeater in
+            if self.isWalletAlreadyCreated(wallet.address) {
+                self.forceFinalizeDeployment(wallet)
+                return
+            }
+            if try checkShouldStop(wallet) {
+                self.repeaters.stop(repeater, wallet: wallet.id)
+            }
+        }
+        repeaters.add(repeater, wallet: wallet.id)
+        try repeater.start()
+    }
+
+    private func isWalletAlreadyCreated(_ address: Address) -> Bool {
+        let blockOrNil = try? DomainRegistry.transactionRelayService.safeCreationTransactionBlock(address: address)
+        return blockOrNil != nil
+    }
+
+    private func forceFinalizeDeployment(_ wallet: Wallet) {
+        repeaters.stopAll(for: wallet.id)
+        wallet.state = wallet.finalizingDeploymentState
+        wallet.proceed()
+    }
+
+    private func updateBalance(for wallet: Wallet) throws -> TokenInt {
+        let token = wallet.feePaymentTokenAddress ?? Token.Ether.address
+        let balance = try self.balance(of: wallet.address, for: token)
+        let accountID = AccountID(tokenID: TokenID(token.value), walletID: wallet.id)
+        let account = DomainRegistry.accountRepository.find(id: accountID)!
+        account.update(newAmount: balance)
+        DomainRegistry.accountRepository.save(account)
+        return balance
+    }
+
     private func balance(of address: Address, for tokenAddress: Address) throws -> TokenInt {
-        return try RetryWithIncreasingDelay(maxAttempts: config.balance.retryAttempts,
-                                            startDelay: config.balance.retryDelay) {
-                if tokenAddress == Token.Ether.address {
-                    return try DomainRegistry.ethereumNodeService.eth_getBalance(account: address)
-                } else {
-                    // NOTE: assuming the ERC20 contract
-                    let proxy = ERC20TokenContractProxy(tokenAddress)
-                    return try proxy.balance(of: address)
-                }
-            }.start()
+        try retryIfFails(params: config.balance) {
+            if tokenAddress == Token.Ether.address {
+                return try DomainRegistry.ethereumNodeService.eth_getBalance(account: address)
+            } else {
+                // NOTE: assuming the ERC20 contract
+                let proxy = ERC20TokenContractProxy(tokenAddress)
+                return try proxy.balance(of: address)
+            }
+        }
     }
 
     private func transactionHash(of wallet: Address) throws -> TransactionHash? {
-        return try RetryWithIncreasingDelay(maxAttempts: config.deploymentStatus.retryAttempts,
-                                            startDelay: config.deploymentStatus.retryDelay) {
-                try DomainRegistry.transactionRelayService.safeCreationTransactionHash(address: wallet)
-            }.start()
+        try retryIfFails(params: config.deploymentStatus) {
+            try DomainRegistry.transactionRelayService.safeCreationTransactionHash(address: wallet)
+        }
     }
 
     private func receipt(of hash: TransactionHash) throws -> TransactionReceipt? {
-        return try RetryWithIncreasingDelay(maxAttempts: config.transactionStatus.retryAttempts,
-                                            startDelay: config.transactionStatus.retryDelay) {
-                try DomainRegistry.ethereumNodeService.eth_getTransactionReceipt(transaction: hash)
-            }.start()
+        try retryIfFails(params: config.transactionStatus) {
+            try DomainRegistry.ethereumNodeService.eth_getTransactionReceipt(transaction: hash)
+        }
+    }
+
+    private func retryIfFails<T>(params: DeploymentDomainServiceConfiguration.Parameters,
+                                 action: @escaping () throws -> T) throws -> T {
+        try RetryWithIncreasingDelay(maxAttempts: params.retryAttempts, startDelay: params.retryDelay, action).start()
     }
 
 }
@@ -330,6 +303,58 @@ public struct DeploymentDomainServiceConfiguration {
         self.balance = balance
         self.deploymentStatus = deploymentStatus
         self.transactionStatus = transactionStatus
+    }
+
+}
+
+extension DeploymentDomainService {
+
+    // Thread-safe repeaters array operations
+    private class Repeaters {
+
+        var repeatersByWallet: [String: [Repeater]] = [:]
+        private let queue = DispatchQueue(label: "DeploymentServiceRepeaterManagementQueue")
+
+        func add(_ repeater: Repeater, wallet id: WalletID) {
+            let id = id.id
+            queue.async { [weak self] in
+                guard let `self` = self else { return }
+                var repeaters = self.repeatersByWallet[id] ?? []
+                repeaters.append(repeater)
+                self.repeatersByWallet[id] = repeaters
+            }
+        }
+
+        func stop(_ repeater: Repeater, wallet id: WalletID) {
+            let id = id.id
+            queue.async { [weak self] in
+                guard let `self` = self else { return }
+                var repeaters = self.repeatersByWallet[id] ?? []
+                repeaters.removeAll { $0 === repeater }
+                self.repeatersByWallet[id] = repeaters
+            }
+        }
+
+        func stopAll(for id: WalletID) {
+            let id = id.id
+            queue.async { [weak self] in
+                guard let `self` = self else { return }
+                let repeaters = self.repeatersByWallet[id] ?? []
+                repeaters.forEach { $0.stop() }
+                self.repeatersByWallet[id] = []
+            }
+        }
+
+        func stopAll() {
+            queue.async { [weak self] in
+                guard let `self` = self else { return }
+                for repeaters in self.repeatersByWallet.values {
+                    repeaters.forEach { $0.stop() }
+                }
+                self.repeatersByWallet = [:]
+            }
+        }
+
     }
 
 }

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/WalletRepository.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/WalletRepository.swift
@@ -12,6 +12,10 @@ public protocol WalletRepository {
     func nextID() -> WalletID
     func all() -> [Wallet]
 
+    /// Finds and returns all wallets in any of the states, sorted by order of creation of wallets
+    /// - Parameter states: set of states to filter by
+    func filter(by states: Set<WalletState.State>) -> [Wallet]
+
 }
 
 public extension WalletRepository {
@@ -23,6 +27,10 @@ public extension WalletRepository {
 
     func find(address: Address) -> Wallet? {
         return all().first { $0.address == address }
+    }
+
+    func filter(by state: WalletState.State) -> [Wallet] {
+        return filter(by: [state])
     }
 
 }

--- a/MultisigWallet/MultisigWalletDomainModelTests/AllDeploymentStatesTests.swift
+++ b/MultisigWallet/MultisigWalletDomainModelTests/AllDeploymentStatesTests.swift
@@ -36,10 +36,28 @@ class AllDeploymentStatesTests: BaseDeploymentDomainServiceTests {
 
         expectSafeCreatedNotification()
 
-        start()
+        XCTAssertNoThrow(try {
+            try self.deploymentService.prepareSafeCreationTransaction(self.wallet)
 
-        wallet = walletRepository.find(id: wallet.id)!
-        XCTAssertTrue(wallet.state === wallet.readyToUseState)
+            _ = try self.deploymentService.checkDidReceiveFirstDeposit(self.wallet)
+
+            _ = try self.deploymentService.checkHasMinimumAmount(self.wallet)
+
+            try self.deploymentService.startSafeCreation(self.wallet)
+
+            _ = try self.deploymentService.checkHasSubmittedTransaction(self.wallet)
+            _ = try self.deploymentService.checkHasSubmittedTransaction(self.wallet)
+            _ = try self.deploymentService.checkHasSubmittedTransaction(self.wallet)
+
+            _ = try self.deploymentService.checkHasMinedTransaction(self.wallet)
+            _ = try self.deploymentService.checkHasMinedTransaction(self.wallet)
+            _ = try self.deploymentService.checkHasMinedTransaction(self.wallet)
+
+            try self.deploymentService.postProcessCreation(self.wallet)
+        }())
+
+        self.updateWallet()
+        XCTAssertTrue(wallet.state === wallet.readyToUseState, "Wallet State: \(wallet.state!)")
     }
 
 }

--- a/MultisigWallet/MultisigWalletDomainModelTests/BaseDeploymentDomainServiceTests.swift
+++ b/MultisigWallet/MultisigWalletDomainModelTests/BaseDeploymentDomainServiceTests.swift
@@ -79,11 +79,11 @@ extension BaseDeploymentDomainServiceTests {
         portfolio.addWallet(wallet.id)
         portfolioRepository.save(portfolio)
         DomainRegistry.accountRepository.save(account)
+        wallet.resume()
     }
 
     func givenConfiguredWallet() {
         givenDraftWalletWithAllOwners()
-        wallet.proceed()
         wallet.changeAddress(Address.safeAddress)
         wallet.updateMinimumTransactionAmount(100)
         wallet.proceed()
@@ -142,6 +142,11 @@ extension BaseDeploymentDomainServiceTests {
     func assertDeploymentCancelled(line: UInt = #line) {
         wallet = walletRepository.find(id: wallet.id)!
         XCTAssertTrue(wallet.state === wallet.newDraftState, line: line)
+    }
+
+    func updateWallet() {
+        assert(wallet != nil)
+        wallet = DomainRegistry.walletRepository.find(id: wallet.id)
     }
 
     @discardableResult

--- a/MultisigWallet/MultisigWalletImplementations/Repositories/DBWalletRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Repositories/DBWalletRepository.swift
@@ -60,4 +60,14 @@ public class DBWalletRepository: DBEntityRepository<Wallet, WalletID>, WalletRep
         return find(id: walletID)
     }
 
+    public func filter(by states: Set<WalletState.State>) -> [Wallet] {
+        guard !states.isEmpty else { return all() }
+        let table = self.table
+        let params = states.map { _ in "?" }.joined(separator: ",")
+        let sql =  "SELECT \(table.fieldNameList) FROM \(table.tableName) WHERE state IN (\(params)) ORDER BY rowid"
+        return try! unwrapped(db.execute(sql: sql,
+                                         bindings: states.map { $0.rawValue },
+                                         resultMap: objectFromResultSet))
+    }
+
 }

--- a/MultisigWallet/MultisigWalletImplementationsTests/DBWalletRepositoryIntegrationTests.swift
+++ b/MultisigWallet/MultisigWalletImplementationsTests/DBWalletRepositoryIntegrationTests.swift
@@ -24,6 +24,13 @@ class DBWalletRepositoryIntegrationTests: XCTestCase {
         let saved = repo.findByID(wallet.id)
         XCTAssertEqual(saved, wallet)
 
+        let wallet2 = Wallet(id: repo.nextID(), owner: Address.testAccount2)
+        wallet2.state = wallet2.deployingState
+        repo.save(wallet2)
+
+        let result = repo.filter(by: [.draft, .deploying]).sorted { $0.id.id < $1.id.id }
+        XCTAssertEqual(result, [wallet, wallet2].sorted { $0.id.id < $1.id.id })
+
         repo.remove(wallet)
         XCTAssertNil(repo.findByID(wallet.id))
     }


### PR DESCRIPTION
- Refactored methods to strip out boilerplate helpers code
- Added walletID to each wallet domain event
- Deployment service will start deploying all wallets that are in creation states
- Unit tests got review and refactoring, too.
- New repository method to filter wallets by state


Roadmap:
- [x] Adjust `DeploymentDomainService` and creation events to use explicit `walletID` instead of `selectedWallet`
- [ ] Adjust flow coordinators: clean up draft safes on startup, before new safe starts, and after create safe flow exits (for any reason)
- [ ] Add menu item to create safe; add "Menu" button to the "no funds" screens.
- [ ] Check that menu is updating on safe status updates
- [ ] On app start: resume deployment service