### PR TITLE
GH-1094 Added clean up of draft safes

### DIFF
--- a/MultisigWallet/CommonTests/InMemoryAccountRepository.swift
+++ b/MultisigWallet/CommonTests/InMemoryAccountRepository.swift
@@ -28,4 +28,8 @@ public class InMemoryAccountRepository: AccountRepository {
         return Array(accounts.values)
     }
 
+    public func filter(walletID: WalletID) -> [Account] {
+        return all().filter { $0.id.walletID == walletID }
+    }
+
 }

--- a/MultisigWallet/CommonTests/InMemoryTransactionRepository.swift
+++ b/MultisigWallet/CommonTests/InMemoryTransactionRepository.swift
@@ -24,4 +24,8 @@ open class InMemoryTransactionRepository: BaseInMemoryRepository<Transaction, Tr
         return TransactionID()
     }
 
+    public func find(wallet: WalletID) -> [Transaction] {
+        return all().filter { $0.accountID.walletID == wallet }
+    }
+
 }

--- a/MultisigWallet/MultisigWalletApplication/WCPendingTransactionsRepository.swift
+++ b/MultisigWallet/MultisigWalletApplication/WCPendingTransactionsRepository.swift
@@ -37,4 +37,7 @@ final class WCPendingTransactionsRepository {
         return pendingTransactions
     }
 
+    func remove(transactionID: TransactionID) {
+        pendingTransactions.removeAll { $0.transactionID == transactionID }
+    }
 }

--- a/MultisigWallet/MultisigWalletApplication/mocks/MockWalletApplicationService.swift
+++ b/MultisigWallet/MultisigWalletApplication/mocks/MockWalletApplicationService.swift
@@ -370,4 +370,12 @@ public class MockWalletApplicationService: WalletApplicationService {
         // empty
     }
 
+    public override func cleanUpDrafts() {
+        // empty
+    }
+
+    public override func wallets() -> [WalletData] {
+        return []
+    }
+
 }

--- a/MultisigWallet/MultisigWalletApplicationTests/WalletApplicationServiceTests/BaseWalletApplicationServiceTests.swift
+++ b/MultisigWallet/MultisigWalletApplicationTests/WalletApplicationServiceTests/BaseWalletApplicationServiceTests.swift
@@ -34,6 +34,7 @@ class BaseWalletApplicationServiceTests: XCTestCase {
     let logger = MockLogger()
     let appSettingsRepository = UserDefaultsAppSettingsRepository()
     let contractMetadataRepository = MockSafeContractMetadataRepository()
+    let wcService = MockWalletConnectApplicationService(chainId: 1)
 
     enum Error: String, LocalizedError, Hashable {
         case walletNotFound
@@ -68,6 +69,7 @@ class BaseWalletApplicationServiceTests: XCTestCase {
         ApplicationServiceRegistry.put(service: eventRelay, for: EventRelay.self)
         ApplicationServiceRegistry.put(service: logger, for: Logger.self)
         ApplicationServiceRegistry.put(service: ethereumService, for: EthereumApplicationService.self)
+        ApplicationServiceRegistry.put(service: wcService, for: WalletConnectApplicationService.self)
 
         ethereumService.prepareToGenerateExternallyOwnedAccount(address: Address.deviceAddress.value,
                                                                 mnemonic: ["a", "b"])

--- a/MultisigWallet/MultisigWalletApplicationTests/WalletApplicationServiceTests/WalletApplicationServiceTests.swift
+++ b/MultisigWallet/MultisigWalletApplicationTests/WalletApplicationServiceTests/WalletApplicationServiceTests.swift
@@ -151,6 +151,22 @@ class WalletApplicationServiceTests: BaseWalletApplicationServiceTests {
         XCTAssertEqual(service.wallets().count, 1)
     }
 
+    func test_removesDraft() {
+        givenDraftWallet()
+        service.cleanUpDrafts()
+        XCTAssertNil(walletRepository.selectedWallet())
+        XCTAssertTrue(service.wallets().isEmpty)
+    }
+
+    func test_whenRemovingWallet_thenRemovesCascadeObjects() {
+        let tx = givenDraftTransaction()
+        let wallet = walletRepository.selectedWallet()!
+        service.removeWallet(wallet.id.id)
+        XCTAssertNil(walletRepository.selectedWallet())
+        XCTAssertNil(transactionRepository.find(id: tx.id))
+        XCTAssertNil(eoaRepo.find(by: wallet.owner(role: .thisDevice)!.address))
+    }
+
     // MARK: - Payment Token
 
     func test_whenFeePaymentTokenIsNil_thenReturnsEther() {

--- a/MultisigWallet/MultisigWalletDomainModel/Account/AccountRepository.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Account/AccountRepository.swift
@@ -30,4 +30,7 @@ public protocol AccountRepository {
     /// - Returns: all accounts
     func all() -> [Account]
 
+    /// Returns all accounts for the wallet id
+    func filter(walletID: WalletID) -> [Account]
+
 }

--- a/MultisigWallet/MultisigWalletDomainModel/Portfolio/Portfolio.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Portfolio/Portfolio.swift
@@ -59,6 +59,8 @@ public class Portfolio: IdentifiableEntity<PortfolioID> {
         wallets.remove(at: index)
         if wallets.isEmpty {
             selectedWallet = nil
+        } else if let id = selectedWallet, !hasWallet(id) {
+            selectedWallet = wallets.first
         }
     }
 

--- a/MultisigWallet/MultisigWalletDomainModel/Transaction/TransactionRepository.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Transaction/TransactionRepository.swift
@@ -39,6 +39,8 @@ public protocol TransactionRepository {
     /// - Returns: found result or nil
     func find(type: TransactionType, wallet: WalletID) -> Transaction?
 
+    func find(wallet: WalletID) -> [Transaction]
+
     /// Generates new transaction identifier
     ///
     /// - Returns: new transaction identifier

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/DeploymentDomainService.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/DeploymentDomainService.swift
@@ -44,6 +44,7 @@ public class DeploymentDomainService {
         let wallet = Wallet(id: DomainRegistry.walletRepository.nextID(), owner: address)
         let account = Account(tokenID: Token.Ether.id, walletID: wallet.id)
         portfolio.addWallet(wallet.id)
+        portfolio.selectWallet(wallet.id)
         DomainRegistry.walletRepository.save(wallet)
         DomainRegistry.portfolioRepository.save(portfolio)
         DomainRegistry.accountRepository.save(account)

--- a/MultisigWallet/MultisigWalletDomainModelTests/PortfolioTests.swift
+++ b/MultisigWallet/MultisigWalletDomainModelTests/PortfolioTests.swift
@@ -36,6 +36,13 @@ class PortfolioTests: XCTestCase {
         XCTAssertNil(portfolio.selectedWallet)
     }
 
+    func test_whenRemovingSelectedWallet_thenSelectsFirstWallet() {
+        portfolio.addWallet(wallet1.id)
+        portfolio.addWallet(wallet2.id)
+        portfolio.removeWallet(wallet1.id)
+        XCTAssertEqual(portfolio.selectedWallet, wallet2.id)
+    }
+
     func test_whenAddingMultipleWallets_thenCanFetchAll() {
         portfolio.addWallet(wallet1.id)
         portfolio.addWallet(wallet2.id)

--- a/MultisigWallet/MultisigWalletImplementations/Repositories/DBAccountRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Repositories/DBAccountRepository.swift
@@ -56,6 +56,12 @@ LIMIT 1;
         return try! db.execute(sql: SQL.all, resultMap: accountFromResultSet).compactMap { $0 }
     }
 
+    public func filter(walletID: WalletID) -> [Account] {
+        let sql = "SELECT id, balance FROM tbl_accounts WHERE id GLOB ? ORDER BY rowid;"
+        let id = "*:" + walletID.id
+        return try! db.execute(sql: sql, bindings: [id], resultMap: accountFromResultSet).compactMap { $0 }
+    }
+
     private func accountFromResultSet(_ rs: ResultSet) -> Account? {
         guard let accountID_id = rs.string(at: 0) else { return nil }
         let balance = rs.string(at: 1)

--- a/MultisigWallet/MultisigWalletImplementations/Repositories/DBTransactionRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Repositories/DBTransactionRepository.swift
@@ -97,6 +97,13 @@ LIMIT 1;
         ORDER BY rowid
         LIMIT 1;
         """
+
+        static let filterByWallet = """
+        SELECT \(fieldList)
+        FROM tbl_transactions
+        WHERE account_id GLOB ?
+        ORDER BY rowid;
+        """
         static let findByHash = "SELECT \(fieldList) FROM tbl_transactions WHERE hash = ? ORDER BY rowid LIMIT 1;"
         static let findAll = "SELECT \(fieldList) FROM tbl_transactions;"
 
@@ -190,6 +197,12 @@ LIMIT 1;
         return try! db.execute(sql: SQL.findByTypeAndWallet,
                                bindings: [type.rawValue, "*:" + wallet.id],
                                resultMap: transactionFromResultSet).first as? Transaction
+    }
+
+    public func find(wallet: WalletID) -> [Transaction] {
+        return try! db.execute(sql: SQL.filterByWallet,
+                               bindings: ["*:" + wallet.id],
+                               resultMap: transactionFromResultSet).compactMap { $0 }
     }
 
     public func all() -> [Transaction] {

--- a/MultisigWallet/MultisigWalletImplementationsTests/DBAccountRepositoryIntegrationTests.swift
+++ b/MultisigWallet/MultisigWalletImplementationsTests/DBAccountRepositoryIntegrationTests.swift
@@ -44,6 +44,9 @@ class DBAccountRepositoryIntegrationTests: XCTestCase {
         XCTAssertEqual(all.count, 2)
         XCTAssertEqual(Set([account, account2]), Set(all))
 
+        let walletAccounts = repo.filter(walletID: walletID)
+        XCTAssertEqual(walletAccounts, all)
+
         repo.remove(account)
         XCTAssertNil(repo.find(id: account.id))
     }

--- a/MultisigWallet/MultisigWalletImplementationsTests/DBTransactionRepositoryTests.swift
+++ b/MultisigWallet/MultisigWalletImplementationsTests/DBTransactionRepositoryTests.swift
@@ -92,8 +92,7 @@ class DBTransactionRepositoryTests: XCTestCase {
             .succeed()
     }
 
-    private func txDraft() -> Transaction {
-        let walletID = WalletID()
+    private func txDraft(walletID: WalletID = WalletID()) -> Transaction {
         let accountID = AccountID(tokenID: Token.gno.id, walletID: walletID)
         return Transaction(id: repo.nextID(), type: .transfer, accountID: accountID)
             .change(amount: .ether(3))
@@ -151,6 +150,11 @@ class DBTransactionRepositoryTests: XCTestCase {
         repo.save(txDraft)
         let found = repo.find(type: txDraft.type, wallet: txDraft.accountID.walletID)
         XCTAssertEqual(found, txDraft)
+
+        let otherTx = self.txDraft(walletID: txDraft.accountID.walletID)
+        repo.save(otherTx)
+        let result = repo.find(wallet: txDraft.accountID.walletID)
+        XCTAssertEqual(result, [txDraft, otherTx])
     }
 
 }

--- a/SafeUIKit/SafeAppUI/MainFlow/MainFlowCoordinator.swift
+++ b/SafeUIKit/SafeAppUI/MainFlow/MainFlowCoordinator.swift
@@ -59,6 +59,9 @@ open class MainFlowCoordinator: FlowCoordinator {
 
     func appDidFinishLaunching() {
         updateUserIdentifier()
+
+        ApplicationServiceRegistry.walletService.cleanUpDrafts()
+
         defer {
             ApplicationServiceRegistry.walletConnectService.subscribeForIncomingTransactions(self)
         }

--- a/SafeUIKit/SafeAppUI/MainFlow/Menu/MenuTableViewControllerTests.swift
+++ b/SafeUIKit/SafeAppUI/MainFlow/Menu/MenuTableViewControllerTests.swift
@@ -43,13 +43,11 @@ class MenuTableViewControllerTests: XCTestCase {
         createWindow(controller)
     }
 
-    var safeSection: Int { return controller.index(of: .safe)! }
     var portfolioSection: Int { return controller.index(of: .portfolio)! }
     var securitySection: Int { return controller.index(of: .security)! }
     var supportSection: Int { return controller.index(of: .support)! }
 
     func test_whenCreated_thenConfigured() {
-        XCTAssertEqual(controller.tableView.numberOfRows(inSection: safeSection), 1)
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: securitySection), 6)
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: portfolioSection), 1)
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: supportSection), 6)
@@ -63,7 +61,6 @@ class MenuTableViewControllerTests: XCTestCase {
     }
 
     func test_whenGettingRow_thenCreatesAppropriateCell() {
-        XCTAssertTrue(cell(row: 0, section: securitySection) is BasicTableViewCell)
         XCTAssertTrue(cell(row: 0, section: portfolioSection) is BasicTableViewCell)
         XCTAssertTrue(cell(row: 0, section: supportSection) is BasicTableViewCell)
         XCTAssertTrue(cell(row: 5, section: supportSection) is AppVersionTableViewCell)
@@ -91,7 +88,7 @@ class MenuTableViewControllerTests: XCTestCase {
     // MARK: - Did select row
 
     func test_whenSelectingCell_thenDeselectsIt() {
-        selectCell(row: 0, section: safeSection)
+        selectCell(row: 0, section: securitySection)
         XCTAssertNil(controller.tableView.indexPathForSelectedRow)
     }
 

--- a/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/CreateSafe/CreateSafeFlowCoordinator.swift
+++ b/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/CreateSafe/CreateSafeFlowCoordinator.swift
@@ -36,6 +36,9 @@ class CreateSafeFlowCoordinator: FlowCoordinator {
                 Tracker.shared.track(event: OnboardingTrackingEvent.newSafeGetStarted)
                 self?.showCreateSafeIntro()
             })
+        vc.onBack = {
+            ApplicationServiceRegistry.walletService.cleanUpDrafts()
+        }
         push(vc)
         onboardingController = vc
     }
@@ -86,6 +89,10 @@ class CreateSafeFlowCoordinator: FlowCoordinator {
         push(controller)
     }
 
+    func finish() {
+        ApplicationServiceRegistry.walletService.cleanUpDrafts()
+        exitFlow()
+    }
 }
 
 extension CreateSafeFlowCoordinator: TwoFATableViewControllerDelegate {
@@ -194,7 +201,7 @@ extension CreateSafeFlowCoordinator: CreationFeePaymentMethodDelegate {
 extension CreateSafeFlowCoordinator: OnboardingCreationFeeViewControllerDelegate {
 
     func deploymentDidFail() {
-        exitFlow()
+        finish()
     }
 
     func deploymentDidStart() {
@@ -202,7 +209,7 @@ extension CreateSafeFlowCoordinator: OnboardingCreationFeeViewControllerDelegate
     }
 
     func deploymentDidCancel() {
-        exitFlow()
+        finish()
     }
 
 }
@@ -210,11 +217,11 @@ extension CreateSafeFlowCoordinator: OnboardingCreationFeeViewControllerDelegate
 extension CreateSafeFlowCoordinator: OnboardingFeePaidViewControllerDelegate {
 
     func onboardingFeePaidDidFail() {
-        exitFlow()
+        finish()
     }
 
     func onboardingFeePaidDidSuccess() {
-        exitFlow()
+        finish()
     }
 
     func onboardingFeePaidOpenMenu() {

--- a/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/OnboardingCreateOrRestoreViewController.swift
+++ b/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/OnboardingCreateOrRestoreViewController.swift
@@ -63,22 +63,27 @@ class OnboardingCreateOrRestoreViewController: UIViewController {
         trackEvent(OnboardingTrackingEvent.createOrRestore)
     }
 
-    @IBAction func createNewSafe(_ sender: Any) {
-        if !ApplicationServiceRegistry.walletService.hasSelectedWallet {
-            ApplicationServiceRegistry.walletService.createNewDraftWallet()
-        } else {
-            ApplicationServiceRegistry.walletService.prepareForCreation()
-        }
+    @IBAction func createNewSafe(_ sender: UIButton) {
+        guard sender.isEnabled else { return }
+        sender.isEnabled = false
+        ApplicationServiceRegistry.walletService.cleanUpDrafts()
+        ApplicationServiceRegistry.walletService.createNewDraftWallet()
         delegate?.didSelectNewSafe()
+        sender.isEnabled = true
     }
 
-    @IBAction func recoverExistingSafe(_ sender: Any) {
+    @IBAction func recoverExistingSafe(_ sender: UIButton) {
+        guard sender.isEnabled else { return }
+        sender.isEnabled = false
+
         if !ApplicationServiceRegistry.walletService.hasSelectedWallet {
             ApplicationServiceRegistry.recoveryService.createRecoverDraftWallet()
         } else {
             ApplicationServiceRegistry.recoveryService.prepareForRecovery()
         }
         delegate?.didSelectRecoverSafe()
+
+        sender.isEnabled = true
     }
 
 

--- a/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/OnboardingCreateOrRestoreViewControllerTests.swift
+++ b/SafeUIKit/SafeAppUI/MainFlow/OnboardingFlow/SetupSafeFlow/OnboardingCreateOrRestoreViewControllerTests.swift
@@ -25,21 +25,21 @@ class OnboardingCreateOrRestoreViewControllerTests: SafeTestCase {
 
     func test_whenNewSafeButtonPressed_thenDelegateCalled() {
         XCTAssertFalse(delegate.pressedNewSafe)
-        vc.createNewSafe(self)
+        vc.createNewSafe(vc.newSafeButton)
         XCTAssertTrue(delegate.pressedNewSafe)
     }
 
     func test_whenNewSafeButtonPressed_thenNewWalletCreated() {
         walletService.expect_hasSelectedWallet(false)
-        vc.createNewSafe(vc as Any)
+        vc.createNewSafe(vc.newSafeButton)
         XCTAssertTrue(walletService.didCreateNewDraft)
     }
 
-    func test_whenNewSafeButtonPressedTwice_thenExistingDraftWalletIsUsed() {
-        vc.createNewSafe(vc as Any)
+    func test_whenNewSafeButtonPressedTwice_thenNewDraftWalletIsUsed() {
+        vc.createNewSafe(vc.newSafeButton)
         walletService.didCreateNewDraft = false
-        vc.createNewSafe(vc as Any)
-        XCTAssertFalse(walletService.didCreateNewDraft)
+        vc.createNewSafe(vc.newSafeButton)
+        XCTAssertTrue(walletService.didCreateNewDraft)
     }
 
     func test_tracking() {

--- a/SafeUIKit/SafeAppUI/ReusableDetachedControllers/Onboarding/OnboardingViewController.swift
+++ b/SafeUIKit/SafeAppUI/ReusableDetachedControllers/Onboarding/OnboardingViewController.swift
@@ -51,6 +51,9 @@ class OnboardingViewController: UIPageViewController, UIPageViewControllerDelega
     let toolbar = OnboardingToolbar()
 
     private weak var _navigationController: UINavigationController!
+    private var backButtonItem: UIBarButtonItem!
+
+    var onBack: (() -> Void)?
 
     static func create(steps: [OnboardingStepInfo]) -> OnboardingViewController {
         let controller = OnboardingViewController(transitionStyle: .scroll,
@@ -93,7 +96,8 @@ class OnboardingViewController: UIPageViewController, UIPageViewControllerDelega
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setCustomBackButton()
+        backButtonItem = UIBarButtonItem.backButton(target: self, action: #selector(back))
+        setCustomBackButton(backButtonItem)
         _navigationController = navigationController
         _navigationController?.navigationBar.shadowImage = UIImage()
     }
@@ -107,6 +111,10 @@ class OnboardingViewController: UIPageViewController, UIPageViewControllerDelega
         if let index = currentPageIndex {
             transition(to: index + 1)
         }
+    }
+
+    @objc func back() {
+        onBack?()
     }
 
     @objc func pageControlChanged() {
@@ -157,6 +165,14 @@ class OnboardingViewController: UIPageViewController, UIPageViewControllerDelega
         if let controller = pageDataSource.stepController(at: index) {
             toolbar.setActionTitle(controller.content?.actionTitle)
         }
+    }
+
+}
+
+extension OnboardingViewController: InteractivePopGestureResponder {
+
+    func interactivePopGestureShouldBegin() -> Bool {
+        return false
     }
 
 }


### PR DESCRIPTION
- New methods on various repositories to find related objects
- Clean up draft wallets on app start, on create new safe start, and create new safe exit.

Roadmap:
- [x] Adjust `DeploymentDomainService` and creation events to use explicit `walletID` instead of `selectedWallet`
- [x] Adjust flow coordinators: clean up draft safes on startup, before new safe starts, and after create safe flow exits (for any reason)
- [ ] Add menu item to create safe; add "Menu" button to the "no funds" screens.
- [ ] Check that menu is updating on safe status updates
- [ ] On app start: resume deployment service