### PR TITLE
GH-1357 Added skeleton for Solidity Contract ABI

### DIFF
--- a/MultisigWallet/MultisigWallet.xcodeproj/project.pbxproj
+++ b/MultisigWallet/MultisigWallet.xcodeproj/project.pbxproj
@@ -102,8 +102,15 @@
 		0A84C2EE230549E60006DA50 /* ExternallyOwnedAccount+TestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1617F82304593B00F6E501 /* ExternallyOwnedAccount+TestFixture.swift */; };
 		0A84C2EF230549E60006DA50 /* WCTestStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAE7D612304544900E7EB07 /* WCTestStubs.swift */; };
 		0A8822F42399350B00093B53 /* WCMultiSendSubTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8822F32399350B00093B53 /* WCMultiSendSubTransaction.swift */; };
+		0A8931F723A287E800183EE6 /* ABITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8931F623A287E800183EE6 /* ABITypes.swift */; };
+		0A8931FD23A288BC00183EE6 /* StandardABICoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8931FC23A288BC00183EE6 /* StandardABICoder.swift */; };
+		0A8931FF23A2A0B400183EE6 /* MultiSendContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8931FE23A2A0B400183EE6 /* MultiSendContract.swift */; };
+		0A89320123A2B22F00183EE6 /* PackedABICoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A89320023A2B22F00183EE6 /* PackedABICoder.swift */; };
+		0A89320323A2B24100183EE6 /* ABICoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A89320223A2B24100183EE6 /* ABICoding.swift */; };
 		0AA21E7D233CD739004A4A62 /* InMemoryTransactionMonitorRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA21E7B233CD70B004A4A62 /* InMemoryTransactionMonitorRepository.swift */; };
 		0AA52701232A6F9E00B2825F /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA52700232A6F9E00B2825F /* LocalizedString.swift */; };
+		0AAA741723A3CF84000799C2 /* StandardABICoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA741623A3CF84000799C2 /* StandardABICoderTests.swift */; };
+		0AAA741D23A3EB34000799C2 /* MultiSendTx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA741C23A3EB34000799C2 /* MultiSendTx.swift */; };
 		0AAE7C42230450A600E7EB07 /* MultisigWalletDomainModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AAE7C39230450A600E7EB07 /* MultisigWalletDomainModel.framework */; };
 		0AAE7C49230450A600E7EB07 /* MultisigWalletDomainModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AAE7C3B230450A600E7EB07 /* MultisigWalletDomainModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0AAE7C62230450B300E7EB07 /* MultisigWalletApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AAE7C59230450B300E7EB07 /* MultisigWalletApplication.framework */; };
@@ -596,12 +603,19 @@
 		0A77D0C3211AD952003582DD /* Fixtures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
 		0A8586D622A17D85003BE36E /* ReplaceRecoveryPhraseApplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceRecoveryPhraseApplicationService.swift; sourceTree = "<group>"; };
 		0A8822F32399350B00093B53 /* WCMultiSendSubTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCMultiSendSubTransaction.swift; sourceTree = "<group>"; };
+		0A8931F623A287E800183EE6 /* ABITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABITypes.swift; sourceTree = "<group>"; };
+		0A8931FC23A288BC00183EE6 /* StandardABICoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardABICoder.swift; sourceTree = "<group>"; };
+		0A8931FE23A2A0B400183EE6 /* MultiSendContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSendContract.swift; sourceTree = "<group>"; };
+		0A89320023A2B22F00183EE6 /* PackedABICoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackedABICoder.swift; sourceTree = "<group>"; };
+		0A89320223A2B24100183EE6 /* ABICoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABICoding.swift; sourceTree = "<group>"; };
 		0A8A2B8F20FCDC4F0003BB7E /* TestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFixture.swift; sourceTree = "<group>"; };
 		0A9E379320F4A4D10085E8D7 /* MockEthereumApplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEthereumApplicationService.swift; sourceTree = "<group>"; };
 		0A9E379820F4A4D10085E8D7 /* EthereumApplicationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumApplicationTestCase.swift; sourceTree = "<group>"; };
 		0A9E379920F4A4D10085E8D7 /* EthereumApplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumApplicationService.swift; sourceTree = "<group>"; };
 		0AA21E7B233CD70B004A4A62 /* InMemoryTransactionMonitorRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryTransactionMonitorRepository.swift; sourceTree = "<group>"; };
 		0AA52700232A6F9E00B2825F /* LocalizedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
+		0AAA741623A3CF84000799C2 /* StandardABICoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardABICoderTests.swift; sourceTree = "<group>"; };
+		0AAA741C23A3EB34000799C2 /* MultiSendTx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSendTx.swift; sourceTree = "<group>"; };
 		0AAAE3E6219AE0A100CB4AA4 /* WalletApplicationServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletApplicationServiceConfiguration.swift; sourceTree = "<group>"; };
 		0AAE7C39230450A600E7EB07 /* MultisigWalletDomainModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MultisigWalletDomainModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AAE7C3B230450A600E7EB07 /* MultisigWalletDomainModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MultisigWalletDomainModel.h; sourceTree = "<group>"; };
@@ -1017,6 +1031,12 @@
 				0AC8A543237C616E00518C65 /* ENSDomainService.swift */,
 				0AAE7CFA2304544800E7EB07 /* GnosisSafeContractProxy.swift */,
 				0AAE7D6E2304544900E7EB07 /* MultiSendContractProxy.swift */,
+				0A8931FE23A2A0B400183EE6 /* MultiSendContract.swift */,
+				0AAA741C23A3EB34000799C2 /* MultiSendTx.swift */,
+				0A89320223A2B24100183EE6 /* ABICoding.swift */,
+				0A8931F623A287E800183EE6 /* ABITypes.swift */,
+				0A8931FC23A288BC00183EE6 /* StandardABICoder.swift */,
+				0A89320023A2B22F00183EE6 /* PackedABICoder.swift */,
 				0AAE7D362304544800E7EB07 /* NotificationService */,
 				0AAE7D5C2304544900E7EB07 /* Portfolio */,
 				0AAE7D6D2304544900E7EB07 /* SafeOwnerManagerContractProxy.swift */,
@@ -1086,6 +1106,7 @@
 				0AAE7E072304569A00E7EB07 /* WalletTests.swift */,
 				0AAE7E0F2304569B00E7EB07 /* WorkerTests.swift */,
 				0AAE7C48230450A600E7EB07 /* Info.plist */,
+				0AAA741623A3CF84000799C2 /* StandardABICoderTests.swift */,
 			);
 			path = MultisigWalletDomainModelTests;
 			sourceTree = "<group>";
@@ -1920,6 +1941,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A89320123A2B22F00183EE6 /* PackedABICoder.swift in Sources */,
 				0AAE7D852304544A00E7EB07 /* ErrorStream.swift in Sources */,
 				559C2EB3231FC1FA0071B14C /* GetSafeStatusRequest.swift in Sources */,
 				0AAE7DA32304544A00E7EB07 /* Worker.swift in Sources */,
@@ -1928,8 +1950,10 @@
 				0AAE7DC92304544A00E7EB07 /* SinglePortfolioRepository.swift in Sources */,
 				0AAE7D792304544A00E7EB07 /* WalletDomainService.swift in Sources */,
 				0AAE7DB02304544A00E7EB07 /* MessageRepository.swift in Sources */,
+				0A8931FF23A2A0B400183EE6 /* MultiSendContract.swift in Sources */,
 				0AAE7DD72304544A00E7EB07 /* BigInt+Hex.swift in Sources */,
 				0AAE7DD22304544A00E7EB07 /* TransactionStatus.swift in Sources */,
+				0A8931FD23A288BC00183EE6 /* StandardABICoder.swift in Sources */,
 				0AAE7DCB2304544A00E7EB07 /* WCSession.swift in Sources */,
 				0AAE7D8A2304544A00E7EB07 /* Owner.swift in Sources */,
 				0AC8A520237C4A9B00518C65 /* ENSContractProxy.swift in Sources */,
@@ -1948,6 +1972,7 @@
 				0A2ACBDF2329005F0054D1D1 /* KeycardKey.swift in Sources */,
 				0AAE7DBB2304544A00E7EB07 /* Account.swift in Sources */,
 				0AAE7DA02304544A00E7EB07 /* EthereumNodeDomainService.swift in Sources */,
+				0AAA741D23A3EB34000799C2 /* MultiSendTx.swift in Sources */,
 				0AAE7D9A2304544A00E7EB07 /* Token.swift in Sources */,
 				0AAE7D712304544A00E7EB07 /* DomainRegistry.swift in Sources */,
 				0AAE7D772304544A00E7EB07 /* DeploymentDomainService.swift in Sources */,
@@ -1977,6 +2002,7 @@
 				0AAE7DA12304544A00E7EB07 /* EthSignature.swift in Sources */,
 				0AAE7DA52304544A00E7EB07 /* ERC20TokenContractProxy.swift in Sources */,
 				0AAE7DD32304544A00E7EB07 /* AppSettingsRepository.swift in Sources */,
+				0A89320323A2B24100183EE6 /* ABICoding.swift in Sources */,
 				0AAE7D922304544A00E7EB07 /* DisconnectTwoFADomainService.swift in Sources */,
 				0AAE7DB52304544A00E7EB07 /* OutgoingMessage.swift in Sources */,
 				0AAE7DCD2304544A00E7EB07 /* WalletConnectDomainService.swift in Sources */,
@@ -2007,6 +2033,7 @@
 				0AAE7DB22304544A00E7EB07 /* TransactionDecisionMessage.swift in Sources */,
 				0AAE7D742304544A00E7EB07 /* WalletRepository.swift in Sources */,
 				0AAE7D752304544A00E7EB07 /* TokenData+Token.swift in Sources */,
+				0A8931F723A287E800183EE6 /* ABITypes.swift in Sources */,
 				0AAE7D822304544A00E7EB07 /* SafeContractMetadata.swift in Sources */,
 				0AAE7DC62304544A00E7EB07 /* TransactionRelayDomainService.swift in Sources */,
 				0A8822F42399350B00093B53 /* WCMultiSendSubTransaction.swift in Sources */,
@@ -2050,6 +2077,7 @@
 				0AAE7E452304569F00E7EB07 /* MockEthereumNodeService1.swift in Sources */,
 				0AAE7E442304569F00E7EB07 /* SubmitTransactionRequestTests.swift in Sources */,
 				0AAE7E402304569F00E7EB07 /* ReplaceTwoFADomainServiceTests.swift in Sources */,
+				0AAA741723A3CF84000799C2 /* StandardABICoderTests.swift in Sources */,
 				0AAE7E3E2304569F00E7EB07 /* ConnectTwoFADomainServiceTests.swift in Sources */,
 				0AAE7E312304569F00E7EB07 /* EthSignatureTests.swift in Sources */,
 				0AAE7E432304569F00E7EB07 /* ReplaceTwoFADomainServiceBaseTestCase.swift in Sources */,

--- a/MultisigWallet/MultisigWalletDomainModel/ABICoding.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/ABICoding.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+protocol ABIEncodable {
+
+    func encode(to encoder: ABIEncoder) throws
+
+}
+
+protocol ABIEncoder: class {
+
+    func encode(_ value: SOLUInt8) throws
+    func encode(_ value: SOLUInt256) throws
+    func encode(_ value: SOLAddress) throws
+    func encode(_ value: SOLBytes) throws
+    func encode(_ value: SOLSelector) throws
+    func encode(_ value: SOLFunctionCall) throws
+    func encode(_ value: SOLTuple) throws
+    func encode<T>(value: T) throws where T: ABIEncodable
+
+    func encode<T>(_ value: T) throws -> Data where T: ABIEncodable
+}
+
+
+protocol ABIDecodable {
+
+    init(from decoder: ABIDecoder) throws
+
+}
+
+protocol ABIDecoder: class {
+
+    func decode(_ type: SOLUInt8.Type) throws -> SOLUInt8
+    func decode(_ type: SOLUInt256.Type) throws -> SOLUInt256
+    func decode(_ type: SOLAddress.Type) throws -> SOLAddress
+    func decode(_ type: SOLBytes.Type) throws -> SOLBytes
+    func decode(_ type: SOLSelector.Type) throws -> SOLSelector
+    func decode(_ type: SOLFunctionCall.Type) throws -> SOLFunctionCall
+    func decode(_ type: SOLTuple.Type) throws -> SOLTuple
+    func decode<T>(type: T.Type) throws -> T where T: ABIDecodable
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: ABIDecodable
+
+    var isAtEnd: Bool { get }
+}
+
+enum ABIDecodingError: Error {
+    case unexpectedFunctionCallSelector
+    case unexpectedValue
+}

--- a/MultisigWallet/MultisigWalletDomainModel/ABITypes.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/ABITypes.swift
@@ -1,0 +1,233 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import BigInt
+
+// MARK: - Introduction
+
+// We declare a set of types that are used in Solidity contracts so that our contract interaction
+// reads naturally in Swift.
+//
+// The integer types are either wrappers around Swift integer types, or around BigInt if they do not fit into
+// standard type system.
+
+// MARK: - SOLUnsignedBinaryInteger
+
+// Allows to implement encoding and decoding algorithms in a generic way
+protocol SOLUnsignedBinaryInteger {
+
+    /// Number of bits in the integer
+    static var bitWidth: Int { get }
+
+    /// Type used as a 'base' for encoding
+    associatedtype Word: SOLUnsignedBinaryInteger
+
+    /// Swift type of integer's value
+    associatedtype Storage: BinaryInteger
+
+    /// Integer value as a Swift type
+    var value: Storage { get }
+
+    /// Right bit-shift operator
+    static func >> (lhs: Self, rhs: Int) -> Self
+
+    /// Bitwise AND operator
+    static func & (lhs: Self, rhs: Int) -> Self
+
+}
+
+/// Allows to initialize any Swift Int/UInt with a SOL-integer
+extension FixedWidthInteger {
+
+    /// Create an integer from a Solidity integer.
+    ///
+    /// NOTE: If the value does not fit into the `FixedWidthInteger`, then this results in runtime error.
+    init<T>(_ value: T) where T: SOLUnsignedBinaryInteger {
+        self.init(value.value)
+    }
+
+}
+
+// MARK: - SOLUInt8
+
+/// Solidity UInt8 unsigned integer type.
+struct SOLUInt8 {
+
+    let value: UInt8
+
+    init(_ value: UInt8) {
+        self.value = value
+    }
+
+    init(_ value: Int) {
+        self.init(UInt8(value))
+    }
+
+}
+
+extension SOLUInt8: ExpressibleByIntegerLiteral {
+
+    init(integerLiteral value: UInt8) {
+        self.init(value)
+    }
+
+}
+
+extension SOLUInt8: ABIEncodable {
+
+    func encode(to encoder: ABIEncoder) throws {
+        try encoder.encode(self)
+    }
+
+}
+
+extension SOLUInt8: SOLUnsignedBinaryInteger {
+
+    typealias Word = SOLUInt256
+
+    typealias Storage = UInt8
+
+    static var bitWidth: Int { return 8 }
+
+    static func >> (lhs: SOLUInt8, rhs: Int) -> SOLUInt8 {
+        SOLUInt8(lhs.value >> rhs)
+    }
+
+    static func & (lhs: SOLUInt8, rhs: Int) -> SOLUInt8 {
+        SOLUInt8(lhs.value & UInt8(rhs))
+    }
+
+}
+
+// MARK: - SOLUInt256
+
+struct SOLUInt256 {
+
+    let value: BigInt
+
+    init(_ value: BigInt) {
+        self.value = value
+    }
+
+}
+
+extension SOLUInt256: SOLUnsignedBinaryInteger {
+
+    static var bitWidth: Int { return 256 }
+
+    typealias Word = SOLUInt256
+
+    typealias Storage = BigInt
+
+    static func >> (lhs: SOLUInt256, rhs: Int) -> SOLUInt256 {
+        preconditionFailure("implement") // TODO
+    }
+
+    static func & (lhs: SOLUInt256, rhs: Int) -> SOLUInt256 {
+        preconditionFailure("implement") // TODO
+    }
+
+}
+
+typealias SOLUInt = SOLUInt256
+
+// MARK: - Not Implemented Yet
+
+// MARK: SOLUInt160 & SOLAddress
+
+struct SOLUInt160 {
+
+    let value: BigInt
+
+}
+
+extension SOLUInt160: SOLUnsignedBinaryInteger {
+
+    static var bitWidth: Int { return 160 }
+
+    typealias Word = SOLUInt256
+
+    static func >> (lhs: SOLUInt160, rhs: Int) -> SOLUInt160 {
+        preconditionFailure("implement") // TODO
+    }
+
+    static func & (lhs: SOLUInt160, rhs: Int) -> SOLUInt160 {
+        preconditionFailure("implement") // TODO
+    }
+
+}
+
+typealias SOLAddress = SOLUInt160
+
+extension SOLAddress {
+
+    init(_ value: Address) {
+        preconditionFailure("implement") // TODO
+    }
+}
+
+struct SOLBool {}
+
+struct SOLBytes32 {}
+
+struct SOLBytes {
+
+    init(_ value: Data) {}
+}
+
+struct SOLArray<T> {}
+
+struct SOLString {}
+
+struct SOLTuple {
+
+    init(_ values: Any...) {}
+}
+
+struct SOLFunctionCall {
+
+    var argumentsData: Data {
+        preconditionFailure()
+    }
+
+    init(selector: String, arguments: ABIEncodable...) {}
+
+    func isSelector(_ value: String) -> Bool {
+        return false
+    }
+}
+
+struct SOLSelector {
+
+    init(_ value: String) {}
+}
+
+extension Int {
+
+    init(_ value: SOLUInt8) {
+        self = 0
+    }
+}
+
+extension Address {
+
+    init(_ value: SOLAddress) {
+        self.init("")
+    }
+}
+
+extension BigInt {
+
+    init(_ value: SOLUInt256) {
+        self.init(0)
+    }
+}
+
+extension Data {
+
+    init(_ value: SOLBytes) {
+        self.init([])
+    }
+}

--- a/MultisigWallet/MultisigWalletDomainModel/MultiSendContract.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/MultiSendContract.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import BigInt
+
+// MultiSend contract allows to atomically execute many transactions in just one ABI call.
+//
+// There are 2 versions of the contract that were used with safe contracts:
+//      - v1: https://github.com/gnosis/safe-contracts/blob/v1.0.0/contracts/libraries/MultiSend.sol
+//      - v2: https://github.com/gnosis/safe-contracts/blob/v1.1.0/contracts/libraries/MultiSend.sol
+//
+// Since multiple versions were used, some old transactions might still have data that we want to show.
+// Therefore, we need to maintain encoding and decoding algorithms for each version.
+//
+// The v1 uses standard Solidity contract ABI encoding, and v2 uses non-standard packed encoding.
+// Both defined in specs: https://solidity.readthedocs.io/en/v0.5.14/abi-spec.html#non-standard-packed-mode
+//
+// The `MultiSendContract` is using a Factory Method approach to select proper encoding based on
+// the contract address. The mapping between contract addresses and version numbers is provided from
+// `SafeContractMetadataRepospitory`.
+//
+// The encoding and decoding of ABI function calls is via `ABIEncodable` and `ABIDecodable` adoption.
+// The function call is represented by a `MultiSendCall` struct.
+class MultiSendContract {
+
+    let address: Address
+    private let codableFactory: ABICodableFactory
+
+    init(_ address: Address) {
+        self.address = address
+        self.codableFactory = MultiSendContract.codableFactory(from: address)
+    }
+
+    func multiSend(_ transactions: [MultiSendTx]) -> Data {
+        let functionCall = MultiSendFunctionCall(transactions: transactions)
+        let encoder = codableFactory.createEncoder()
+        return try! encoder.encode(functionCall)
+    }
+
+    func decodeMultiSend(_ data: Data) -> [MultiSendTx]? {
+        let decoder = codableFactory.createDecoder()
+        let functionCall = try? decoder.decode(MultiSendFunctionCall.self, from: data)
+        return functionCall?.transactions
+    }
+
+    // Switches between different contract verseions
+    private class func codableFactory(from address: Address) -> ABICodableFactory {
+        let version = DomainRegistry.safeContractMetadataRepository.version(multiSendAddress: address)
+        switch version {
+        case .some(1):
+            return ContractV1()
+        default:
+            return ContractV2()
+        }
+    }
+
+    private class ContractV1: ABICodableFactory {
+        func createEncoder() -> ABIEncoder {
+            StandardABIEncoder()
+        }
+        func createDecoder() -> ABIDecoder {
+            StandardABIDecoder()
+        }
+    }
+
+    private class ContractV2: ABICodableFactory {
+        func createEncoder() -> ABIEncoder {
+            PackedABIEncoder()
+        }
+        func createDecoder() -> ABIDecoder {
+            PackedABIDecoder()
+        }
+    }
+
+}
+
+
+// This factory interface allows to switch between encoders at runtime
+fileprivate protocol ABICodableFactory {
+
+    func createEncoder() -> ABIEncoder
+    func createDecoder() -> ABIDecoder
+
+}
+
+fileprivate struct MultiSendFunctionCall {
+
+    let selector = "multiSend(bytes)"
+    var transactions: [MultiSendTx]
+
+}
+
+extension MultiSendFunctionCall: ABIEncodable {
+
+    func encode(to encoder: ABIEncoder) throws {
+        let call = SOLFunctionCall(selector: selector, arguments: transactions)
+        try encoder.encode(call)
+    }
+
+}
+
+extension MultiSendFunctionCall: ABIDecodable {
+
+    init(from decoder: ABIDecoder) throws {
+        let call = try decoder.decode(SOLFunctionCall.self)
+        guard call.isSelector(selector) else {
+            throw ABIDecodingError.unexpectedFunctionCallSelector
+        }
+        transactions = try decoder.decode([MultiSendTx].self, from: call.argumentsData)
+    }
+
+}

--- a/MultisigWallet/MultisigWalletDomainModel/MultiSendTx.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/MultiSendTx.swift
@@ -1,0 +1,80 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import BigInt
+
+struct MultiSendTx {
+
+    var operation: Operation
+    var to: Address
+    var value: BigInt
+    var data: Data
+
+    enum Operation: Int {
+        // if there is another contract function call inside `data`, it will be called as a normal call-return.
+        case call = 0
+        // if there is another contract function call inside `data`, then that code will be dynamically loaded
+        // and executed within context of the `multiSend()` function of the `MultiSend` smart contract.
+        case delegateCall = 1
+    }
+
+}
+
+extension MultiSendTx: ABIEncodable {
+
+    func encode(to encoder: ABIEncoder) throws {
+        try encoder.encode(
+            SOLTuple(
+                SOLUInt8(operation.rawValue),
+                SOLAddress(to),
+                SOLUInt256(value),
+                SOLBytes(data)
+            )
+        )
+    }
+
+}
+
+extension MultiSendTx: ABIDecodable {
+
+    init(from decoder: ABIDecoder) throws {
+        let operationRawValue = try decoder.decode(SOLUInt8.self)
+
+        guard let operation = Operation(rawValue: Int(operationRawValue)) else {
+            throw ABIDecodingError.unexpectedValue
+        }
+
+        self.operation = operation
+        self.to = try Address(decoder.decode(SOLAddress.self))
+        self.value = try BigInt(decoder.decode(SOLUInt256.self))
+        self.data = try Data(decoder.decode(SOLBytes.self))
+    }
+
+}
+
+// MARK: - [MultiSendTx]
+
+extension Array: ABIEncodable where Element == MultiSendTx {
+
+    func encode(to encoder: ABIEncoder) throws {
+        for tx in self {
+            try encoder.encode(value: tx)
+        }
+    }
+
+}
+
+extension Array: ABIDecodable where Element == MultiSendTx {
+
+    init(from decoder: ABIDecoder) throws {
+        var result: [MultiSendTx] = []
+        while !decoder.isAtEnd {
+            let transaction = try decoder.decode(type: MultiSendTx.self)
+            result.append(transaction)
+        }
+        self = result
+    }
+
+}

--- a/MultisigWallet/MultisigWalletDomainModel/PackedABICoder.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/PackedABICoder.swift
@@ -1,0 +1,90 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+
+class PackedABIEncoder: ABIEncoder {
+    func encode(_ value: SOLUInt8) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLUInt256) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLAddress) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLBytes) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLSelector) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLFunctionCall) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode(_ value: SOLTuple) throws {
+        preconditionFailure("implement")
+    }
+
+    func encode<T>(value: T) throws where T : ABIEncodable {
+        preconditionFailure("implement")
+    }
+
+    func encode<T>(_ value: T) throws -> Data where T : ABIEncodable {
+        preconditionFailure("implement")
+    }
+
+
+}
+
+class PackedABIDecoder: ABIDecoder {
+    func decode(_ type: SOLUInt8.Type) throws -> SOLUInt8 {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLUInt256.Type) throws -> SOLUInt256 {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLAddress.Type) throws -> SOLAddress {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLBytes.Type) throws -> SOLBytes {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLSelector.Type) throws -> SOLSelector {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLFunctionCall.Type) throws -> SOLFunctionCall {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLTuple.Type) throws -> SOLTuple {
+        preconditionFailure("implement")
+    }
+
+    func decode<T>(type: T.Type) throws -> T where T : ABIDecodable {
+        preconditionFailure("implement")
+    }
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : ABIDecodable {
+        preconditionFailure("implement")
+    }
+
+    var isAtEnd: Bool {
+        preconditionFailure("implement")
+    }
+
+
+}

--- a/MultisigWallet/MultisigWalletDomainModel/StandardABICoder.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/StandardABICoder.swift
@@ -1,0 +1,100 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+// https://solidity.readthedocs.io/en/v0.5.14/abi-spec.html
+
+class StandardABIEncoder: ABIEncoder {
+
+    private var container: Data = Data()
+
+    // Encodes SOLUInt<N> value to a binary container
+    func encode<T>(_ value: T) throws where T: SOLUnsignedBinaryInteger {
+        assert(T.bitWidth <= T.Word.bitWidth)
+
+        // 1. Encode integer value to Big-endian encoding
+        let sizeOfValueInBytes = T.bitWidth / 8
+        let bigEndianByteSequence = (0..<sizeOfValueInBytes).reversed()
+
+        let valueAsBytes = bigEndianByteSequence.map { byteIndex -> UInt8 in
+            let bitsToShift = byteIndex * 8
+            return UInt8(value >> bitsToShift & 0xFF)
+        }
+
+        // 2. Pad with 0 bytes to the Word size
+        let bytesInWord = T.Word.bitWidth / 8
+        let padding = Data(repeating: 0, count: bytesInWord - valueAsBytes.count)
+        let encoded = padding + Data(valueAsBytes)
+
+        assert(encoded.count == bytesInWord)
+        container.append(encoded)
+    }
+
+    func encode(_ value: SOLBytes) throws {
+        // TODO: implement
+    }
+
+    func encode(_ value: SOLSelector) throws {
+        // TODO: implement
+    }
+
+    func encode(_ value: SOLFunctionCall) throws {
+        // TODO: implement
+    }
+
+    func encode(_ value: SOLTuple) throws {
+        // TODO: implement
+    }
+
+    func encode<T>(value: T) throws where T : ABIEncodable {
+        // TODO: implement
+    }
+
+    func encode<T>(_ value: T) throws -> Data where T : ABIEncodable {
+        try value.encode(to: self)
+        return container
+        preconditionFailure("not implemented")
+    }
+
+}
+
+class StandardABIDecoder: ABIDecoder {
+
+    func decode(_ type: SOLUInt8.Type) throws -> SOLUInt8 {
+        preconditionFailure("implement")    }
+
+    func decode(_ type: SOLUInt256.Type) throws -> SOLUInt256 {
+        preconditionFailure("implement")    }
+
+    func decode(_ type: SOLAddress.Type) throws -> SOLAddress {
+        preconditionFailure("implement")
+    }
+
+    func decode(_ type: SOLBytes.Type) throws -> SOLBytes {
+        preconditionFailure("implement")    }
+
+    func decode(_ type: SOLSelector.Type) throws -> SOLSelector {
+        preconditionFailure("implement")    }
+
+    func decode(_ type: SOLFunctionCall.Type) throws -> SOLFunctionCall {
+        preconditionFailure("implement")    }
+
+    func decode(_ type: SOLTuple.Type) throws -> SOLTuple {
+        preconditionFailure("implement")    }
+
+    func decode<T>(type: T.Type) throws -> T where T : ABIDecodable {
+        preconditionFailure("implement")
+    }
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : ABIDecodable {
+        preconditionFailure("implement")
+    }
+
+    var isAtEnd: Bool {
+        preconditionFailure("implement")
+    }
+
+
+}

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/SafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/SafeContractMetadataRepository.swift
@@ -6,7 +6,6 @@ import Foundation
 
 public protocol SafeContractMetadataRepository {
 
-    var multiSendContractAddress: Address { get }
     var proxyFactoryAddress: Address { get }
 
     var latestMasterCopyAddress: Address { get }
@@ -20,5 +19,10 @@ public protocol SafeContractMetadataRepository {
     func deploymentCode(masterCopyAddress: Address) -> Data?
     func EIP712SafeAppTxTypeHash(masterCopyAddress: Address) -> Data?
     func EIP712SafeAppDomainSeparatorTypeHash(masterCopyAddress: Address) -> Data?
+
+    /// Default multi send contract address
+    var multiSendContractAddress: Address { get }
+    func version(multiSendAddress: Address) -> Int?
+//    func isValidMultiSend(address: Address) -> Bool
 
 }

--- a/MultisigWallet/MultisigWalletDomainModel/Wallet/SafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletDomainModel/Wallet/SafeContractMetadataRepository.swift
@@ -23,6 +23,5 @@ public protocol SafeContractMetadataRepository {
     /// Default multi send contract address
     var multiSendContractAddress: Address { get }
     func version(multiSendAddress: Address) -> Int?
-//    func isValidMultiSend(address: Address) -> Bool
 
 }

--- a/MultisigWallet/MultisigWalletDomainModelTests/StandardABICoderTests.swift
+++ b/MultisigWallet/MultisigWalletDomainModelTests/StandardABICoderTests.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright © 2019 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import MultisigWalletDomainModel
+
+class StandardABICoderTests: XCTestCase {
+
+    func test_uint8() throws {
+        assertEqual(0x00, hex: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00")
+        assertEqual(0x01, hex: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01")
+        assertEqual(0xAB, hex: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 AB")
+        assertEqual(0xFF, hex: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 FF")
+    }
+
+    private func assertEqual(_ lhs: SOLUInt8, hex rhs: String, line: UInt = #line) {
+        XCTAssertNoThrow(try {
+            let actual: Data = try StandardABIEncoder().encode(lhs)
+            let expected = Data(hexString: rhs)
+            XCTAssertEqual(actual, expected, "\(actual.hexString) != \(expected.hexString)", line: line)
+        }())
+    }
+}
+
+fileprivate extension Data {
+
+    init(hexString: String) {
+        self.init(hex: hexString.replacingOccurrences(of: " ", with: ""))
+    }
+
+    var hexString: String {
+        self.map { String(format: "%02X", $0) }.joined(separator: " ")
+    }
+
+}

--- a/MultisigWallet/MultisigWalletImplementations/MockRepositories/MockSafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/MockRepositories/MockSafeContractMetadataRepository.swift
@@ -6,10 +6,6 @@ import Foundation
 import MultisigWalletDomainModel
 
 public class MockSafeContractMetadataRepository: SafeContractMetadataRepository {
-    public func version(multiSendAddress: Address) -> Int? {
-        return nil
-    }
-
 
     public var multiSendContractAddress: Address
     public var proxyFactoryAddress: Address
@@ -57,6 +53,10 @@ public class MockSafeContractMetadataRepository: SafeContractMetadataRepository 
     }
 
     public func EIP712SafeAppDomainSeparatorTypeHash(masterCopyAddress: Address) -> Data? {
+        return nil
+    }
+
+    public func version(multiSendAddress: Address) -> Int? {
         return nil
     }
 

--- a/MultisigWallet/MultisigWalletImplementations/MockRepositories/MockSafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/MockRepositories/MockSafeContractMetadataRepository.swift
@@ -6,6 +6,10 @@ import Foundation
 import MultisigWalletDomainModel
 
 public class MockSafeContractMetadataRepository: SafeContractMetadataRepository {
+    public func version(multiSendAddress: Address) -> Int? {
+        return nil
+    }
+
 
     public var multiSendContractAddress: Address
     public var proxyFactoryAddress: Address

--- a/MultisigWallet/MultisigWalletImplementations/Repositories/InMemorySafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Repositories/InMemorySafeContractMetadataRepository.swift
@@ -6,10 +6,6 @@ import Foundation
 import MultisigWalletDomainModel
 
 public class InMemorySafeContractMetadataRepository: SafeContractMetadataRepository {
-    public func version(multiSendAddress: Address) -> Int? {
-        return nil
-    }
-
 
     private let metadata: SafeContractMetadata
 
@@ -66,6 +62,10 @@ public class InMemorySafeContractMetadataRepository: SafeContractMetadataReposit
 
     private subscript(_ address: Address) -> MasterCopyMetadata? {
         return metadata.metadata.first { $0.address.value.lowercased() == address.value.lowercased() }
+    }
+
+    public func version(multiSendAddress: Address) -> Int? {
+        preconditionFailure("implement") // TODO: implement
     }
 
 }

--- a/MultisigWallet/MultisigWalletImplementations/Repositories/InMemorySafeContractMetadataRepository.swift
+++ b/MultisigWallet/MultisigWalletImplementations/Repositories/InMemorySafeContractMetadataRepository.swift
@@ -6,6 +6,10 @@ import Foundation
 import MultisigWalletDomainModel
 
 public class InMemorySafeContractMetadataRepository: SafeContractMetadataRepository {
+    public func version(multiSendAddress: Address) -> Int? {
+        return nil
+    }
+
 
     private let metadata: SafeContractMetadata
 

--- a/MultisigWallet/MultisigWalletImplementationsTests/EncryptionServiceTests.swift
+++ b/MultisigWallet/MultisigWalletImplementationsTests/EncryptionServiceTests.swift
@@ -458,6 +458,11 @@ typealias mAddress = MultisigWalletDomainModel.Address
 // TODO: should we delete it as duplicate of SafeContractMetadataRepository.swift ?
 class MockSafeContractMetadataRepository: SafeContractMetadataRepository {
 
+    func version(multiSendAddress: MultisigWalletDomainModel.Address) -> Int? {
+        nil
+    }
+
+
     var multiSendContractAddress: mAddress { return .zero }
     var latestMasterCopyAddress: mAddress { return .zero }
 

--- a/MultisigWallet/MultisigWalletImplementationsTests/EncryptionServiceTests.swift
+++ b/MultisigWallet/MultisigWalletImplementationsTests/EncryptionServiceTests.swift
@@ -458,11 +458,6 @@ typealias mAddress = MultisigWalletDomainModel.Address
 // TODO: should we delete it as duplicate of SafeContractMetadataRepository.swift ?
 class MockSafeContractMetadataRepository: SafeContractMetadataRepository {
 
-    func version(multiSendAddress: MultisigWalletDomainModel.Address) -> Int? {
-        nil
-    }
-
-
     var multiSendContractAddress: mAddress { return .zero }
     var latestMasterCopyAddress: mAddress { return .zero }
 
@@ -502,6 +497,10 @@ class MockSafeContractMetadataRepository: SafeContractMetadataRepository {
 
     func EIP712SafeAppDomainSeparatorTypeHash(masterCopyAddress: mAddress) -> Data? {
         return nil
+    }
+
+    func version(multiSendAddress: MultisigWalletDomainModel.Address) -> Int? {
+        nil
     }
 
 }


### PR DESCRIPTION
  - Added new implementation of a MultiSend contract
  - Added skeleton of the Contract ABI Encoding / Decoding
  - Implemented encoding of Solidity UInt8 and UInt256

The new MultiSend implementation, when it becomes ready, will replace existing MultiSendContractProxy.